### PR TITLE
fix: corriger le script tauri utilise en release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri dev"
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Evite que le workflow de release lance tauri en mode dev avec Vite et un watcher Rust, afin que la publication puisse terminer proprement.

Made-with: Cursor