### PR TITLE
feat: add configurable display and focus mode hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.1.3-111827?style=for-the-badge" />
+  <img alt="Version" src="https://img.shields.io/badge/version-0.1.4-111827?style=for-the-badge" />
   <img alt="License" src="https://img.shields.io/badge/license-MIT-111827?style=for-the-badge" />
 </p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nocturn",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nocturn",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nocturn",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Nocturn desktop application",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1884,7 +1884,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nocturn"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -981,6 +981,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1121,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -1863,6 +1891,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "windows-sys 0.61.2",
@@ -3470,6 +3499,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-process"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4986,6 +5030,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4994,6 +5055,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nocturn"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 build = "build.rs"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tauri = { version = "2.10.3", features = ["tray-icon", "unstable"] }
+tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-updater = "2.10.0"
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Storage_FileSystem", "Win32_System_LibraryLoader", "Win32_System_ProcessStatus", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging", "Win32_Devices_Display"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -148,6 +148,48 @@ pub fn set_shortcut_settings(
 }
 
 #[command]
+pub fn reset_to_defaults(
+    app: AppHandle,
+    state: State<'_, SharedState>,
+) -> Result<DisplayUpdatePayload, String> {
+    ensure_displays_loaded(&app, state.inner())?;
+
+    let previous_settings = {
+        let state = state.lock().expect("state poisoned");
+        state.settings.clone()
+    };
+
+    let mut next_settings = settings::AppSettings::default();
+    next_settings.shortcut_defaults_initialized = false;
+
+    {
+        let mut state = state.lock().expect("state poisoned");
+        state.settings = next_settings;
+    }
+
+    let _ = shortcuts::ensure_default_shortcuts(&app, state.inner())?;
+
+    let current_settings = {
+        let state = state.lock().expect("state poisoned");
+        state.settings.clone()
+    };
+
+    if let Err(error) = shortcuts::sync_registered_shortcuts(&app, state.inner()) {
+        restore_previous_settings(&app, state.inner(), &previous_settings);
+        return Err(error);
+    }
+
+    if let Err(error) = settings::save_settings(&app, &current_settings) {
+        restore_previous_settings(&app, state.inner(), &previous_settings);
+        return Err(error);
+    }
+
+    sync_runtime_behaviors(state.inner());
+    emit_displays_update(&app, state.inner())?;
+    build_payload(&app, state.inner())
+}
+
+#[command]
 pub fn toggle_display(
     app: AppHandle,
     state: State<'_, SharedState>,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,8 +8,11 @@ use log::{error, info, warn};
 use tauri::{command, AppHandle, Emitter, Manager, Monitor, State};
 
 use crate::{
-    cursor, overlay, panel, settings,
-    state::{DisplayInfo, DisplayState, DisplayUpdatePayload, NocturnState},
+    cursor, overlay, panel, settings, shortcuts,
+    state::{
+        DisplayInfo, DisplayShortcutBindingInfo, DisplayState, DisplayUpdatePayload, NocturnState,
+        ShortcutAction, ShortcutSettingsPayload,
+    },
     window_inventory,
 };
 
@@ -41,6 +44,7 @@ pub fn get_displays(
     state: State<'_, SharedState>,
 ) -> Result<DisplayUpdatePayload, String> {
     ensure_displays_loaded(&app, state.inner())?;
+    let _ = shortcuts::ensure_default_shortcuts(&app, state.inner())?;
     sync_runtime_behaviors(state.inner());
     build_payload(&app, state.inner())
 }
@@ -96,6 +100,46 @@ pub fn set_show_overlay_hidden_apps(
     if let Err(error) = settings::save_settings(&app, &next_settings) {
         let mut state = state.lock().expect("state poisoned");
         state.settings = previous_settings;
+        return Err(error);
+    }
+
+    emit_displays_update(&app, state.inner())?;
+    build_payload(&app, state.inner())
+}
+
+#[command]
+pub fn set_shortcut_settings(
+    app: AppHandle,
+    state: State<'_, SharedState>,
+    hotkeys: settings::ShortcutSettings,
+) -> Result<DisplayUpdatePayload, String> {
+    ensure_displays_loaded(&app, state.inner())?;
+
+    let previous_settings = {
+        let state = state.lock().expect("state poisoned");
+        state.settings.clone()
+    };
+
+    let sanitized_shortcut_settings =
+        shortcuts::sanitize_shortcut_settings(state.inner(), hotkeys)?;
+    let next_settings = settings::AppSettings {
+        shortcut_settings: sanitized_shortcut_settings,
+        shortcut_defaults_initialized: true,
+        ..previous_settings.clone()
+    };
+
+    {
+        let mut state = state.lock().expect("state poisoned");
+        state.settings = next_settings.clone();
+    }
+
+    if let Err(error) = shortcuts::sync_registered_shortcuts(&app, state.inner()) {
+        restore_previous_settings(&app, state.inner(), &previous_settings);
+        return Err(error);
+    }
+
+    if let Err(error) = settings::save_settings(&app, &next_settings) {
+        restore_previous_settings(&app, state.inner(), &previous_settings);
         return Err(error);
     }
 
@@ -396,12 +440,65 @@ fn toggle_display_internal(
     Ok("Display blacked out.".to_string())
 }
 
+pub(crate) fn execute_shortcut_action(
+    app: &AppHandle,
+    state: &SharedState,
+    action: ShortcutAction,
+) -> Result<(), String> {
+    let _guard = ToggleGuard::acquire(state)?;
+
+    match action {
+        ShortcutAction::FocusMode => focus_primary_internal(app, state).map(|_| ()),
+        ShortcutAction::ToggleDisplay { display_key } => {
+            ensure_displays_loaded(app, state)?;
+
+            let display_id = {
+                let state = state.lock().expect("state poisoned");
+                state
+                    .displays
+                    .values()
+                    .find(|display| display.persistent_key == display_key)
+                    .map(|display| display.id.clone())
+                    .ok_or_else(|| {
+                        "Display for this shortcut is not currently available.".to_string()
+                    })?
+            };
+
+            toggle_display_internal(app, state, &display_id).map(|_| ())
+        }
+    }
+}
+
 fn sync_runtime_behaviors(state: &SharedState) {
     cursor::sync_cursor_confinement(state);
 }
 
 pub fn refresh_display_snapshot(app: &AppHandle, state: &SharedState) -> Result<(), String> {
+    refresh_displays(app, state)?;
+    let shortcuts_initialized = shortcuts::ensure_default_shortcuts(app, state)?;
+    if !shortcuts_initialized {
+        shortcuts::sync_registered_shortcuts(app, state)?;
+    }
+    sync_runtime_behaviors(state);
     emit_displays_update(app, state)
+}
+
+fn restore_previous_settings(
+    app: &AppHandle,
+    state: &SharedState,
+    previous_settings: &settings::AppSettings,
+) {
+    {
+        let mut state = state.lock().expect("state poisoned");
+        state.settings = previous_settings.clone();
+    }
+
+    if let Err(error) = shortcuts::sync_registered_shortcuts(app, state) {
+        error!(
+            "restore_previous_settings: failed to restore shortcuts: {}",
+            error
+        );
+    }
 }
 
 fn emit_displays_update(app: &AppHandle, state: &SharedState) -> Result<(), String> {
@@ -411,12 +508,18 @@ fn emit_displays_update(app: &AppHandle, state: &SharedState) -> Result<(), Stri
 }
 
 fn build_payload(app: &AppHandle, state: &SharedState) -> Result<DisplayUpdatePayload, String> {
-    let (displays_map, allow_cursor_exit_active_displays, show_overlay_hidden_apps) = {
+    let (
+        displays_map,
+        allow_cursor_exit_active_displays,
+        show_overlay_hidden_apps,
+        shortcut_settings,
+    ) = {
         let state = state.lock().expect("state poisoned");
         (
             state.displays.clone(),
             state.settings.allow_cursor_exit_active_displays,
             state.settings.show_overlay_hidden_apps,
+            state.settings.shortcut_settings.clone(),
         )
     };
     let active_display_count = displays_map
@@ -435,6 +538,31 @@ fn build_payload(app: &AppHandle, state: &SharedState) -> Result<DisplayUpdatePa
         show_overlay_hidden_apps,
     );
     overlay::sync_overlay_cards(app, &displays_map, overlay_presentations)?;
+    let available_display_keys = displays_map
+        .values()
+        .map(|display| display.persistent_key.as_str())
+        .collect::<HashSet<_>>();
+    let hotkeys_by_display_key = shortcut_settings
+        .display_bindings
+        .iter()
+        .map(|binding| (binding.display_key.as_str(), binding.accelerator.clone()))
+        .collect::<HashMap<_, _>>();
+    let mut display_bindings = shortcut_settings
+        .display_bindings
+        .iter()
+        .map(|binding| DisplayShortcutBindingInfo {
+            display_key: binding.display_key.clone(),
+            display_label: binding.display_label.clone(),
+            accelerator: binding.accelerator.clone(),
+            is_available: available_display_keys.contains(binding.display_key.as_str()),
+        })
+        .collect::<Vec<_>>();
+
+    display_bindings.sort_by(|left, right| {
+        left.display_label
+            .cmp(&right.display_label)
+            .then_with(|| left.display_key.cmp(&right.display_key))
+    });
 
     let mut displays = displays_map
         .values()
@@ -448,6 +576,7 @@ fn build_payload(app: &AppHandle, state: &SharedState) -> Result<DisplayUpdatePa
                 name: display.name,
                 manufacturer: display.manufacturer,
                 model: display.model,
+                persistent_key: display.persistent_key.clone(),
                 width: display.width,
                 height: display.height,
                 x: display.x,
@@ -457,6 +586,9 @@ fn build_payload(app: &AppHandle, state: &SharedState) -> Result<DisplayUpdatePa
                 orientation: display.orientation,
                 is_primary: display.is_primary,
                 is_blacked_out: display.is_blacked_out,
+                hotkey: hotkeys_by_display_key
+                    .get(display.persistent_key.as_str())
+                    .cloned(),
                 hidden_apps: hidden_apps_by_display
                     .get(&display_id)
                     .cloned()
@@ -473,6 +605,10 @@ fn build_payload(app: &AppHandle, state: &SharedState) -> Result<DisplayUpdatePa
         blackout_count,
         allow_cursor_exit_active_displays,
         show_overlay_hidden_apps,
+        shortcut_settings: ShortcutSettingsPayload {
+            focus_mode_hotkey: shortcut_settings.focus_mode_hotkey,
+            display_bindings,
+        },
     })
 }
 
@@ -756,6 +892,11 @@ fn monitor_to_display_state(
         name,
         manufacturer: identity.manufacturer,
         model: identity.model,
+        persistent_key: if identity.persistent_key.is_empty() {
+            format!("gdi:{}", id)
+        } else {
+            identity.persistent_key
+        },
         width: size.width,
         height: size.height,
         x: position.x,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod monitor_info;
 mod overlay;
 mod panel;
 mod settings;
+mod shortcuts;
 mod state;
 mod window_inventory;
 
@@ -24,6 +25,14 @@ fn main() {
 
     tauri::Builder::default()
         .manage(shared_state)
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app, shortcut, event| {
+                    let state = app.state::<SharedState>();
+                    shortcuts::handle_shortcut_event(app, shortcut, event, state.inner());
+                })
+                .build(),
+        )
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
@@ -31,6 +40,7 @@ fn main() {
             commands::get_overlay_card_presentation,
             commands::set_allow_cursor_exit_active_displays,
             commands::set_show_overlay_hidden_apps,
+            commands::set_shortcut_settings,
             commands::toggle_display,
             commands::unblank_all,
             commands::focus_primary,
@@ -105,7 +115,7 @@ fn main() {
                 }
             });
 
-            let _ = commands::get_displays(app.handle().clone(), state);
+            let _ = commands::refresh_display_snapshot(app.handle(), state.inner());
 
             Ok(())
         })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
             commands::set_allow_cursor_exit_active_displays,
             commands::set_show_overlay_hidden_apps,
             commands::set_shortcut_settings,
+            commands::reset_to_defaults,
             commands::toggle_display,
             commands::unblank_all,
             commands::focus_primary,

--- a/src-tauri/src/monitor_info.rs
+++ b/src-tauri/src/monitor_info.rs
@@ -16,6 +16,7 @@ use windows_sys::Win32::Graphics::Gdi::{EnumDisplaySettingsW, DEVMODEW, ENUM_CUR
 pub struct MonitorIdentity {
     pub manufacturer: String,
     pub model: String,
+    pub persistent_key: String,
 }
 
 /// Query refresh rate and orientation for a GDI device name (e.g. `\\.\DISPLAY1`).
@@ -121,18 +122,39 @@ pub fn query_monitor_identities() -> HashMap<String, MonitorIdentity> {
 
             // Model = friendly name with manufacturer prefix stripped
             let model = extract_model(&friendly_name, &manufacturer, &pnp_code);
+            let persistent_key = build_persistent_display_key(
+                path.sourceInfo.adapterId.HighPart as u32,
+                path.sourceInfo.adapterId.LowPart,
+                path.sourceInfo.id,
+                path.targetInfo.id,
+                &gdi_name,
+            );
 
             map.insert(
                 gdi_name,
                 MonitorIdentity {
                     manufacturer,
                     model,
+                    persistent_key,
                 },
             );
         }
 
         map
     }
+}
+
+fn build_persistent_display_key(
+    adapter_high: u32,
+    adapter_low: u32,
+    source_id: u32,
+    target_id: u32,
+    gdi_name: &str,
+) -> String {
+    format!(
+        "connector:{adapter_high:08X}:{adapter_low:08X}:{source_id}:{target_id}:{}",
+        gdi_name.to_uppercase()
+    )
 }
 
 /// Decode a 16-bit EDID manufacturer ID into a 3-letter PNP code.

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -3,11 +3,28 @@ use std::{fs, path::PathBuf};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct DisplayHotkeyBinding {
+    pub display_key: String,
+    pub display_label: String,
+    pub accelerator: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ShortcutSettings {
+    pub focus_mode_hotkey: Option<String>,
+    pub display_bindings: Vec<DisplayHotkeyBinding>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct AppSettings {
     pub allow_cursor_exit_active_displays: bool,
     pub show_overlay_hidden_apps: bool,
+    pub shortcut_settings: ShortcutSettings,
+    pub shortcut_defaults_initialized: bool,
 }
 
 impl Default for AppSettings {
@@ -15,6 +32,8 @@ impl Default for AppSettings {
         Self {
             allow_cursor_exit_active_displays: true,
             show_overlay_hidden_apps: true,
+            shortcut_settings: ShortcutSettings::default(),
+            shortcut_defaults_initialized: false,
         }
     }
 }

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -256,6 +256,10 @@ fn parse_shortcut(raw: &str) -> Result<Shortcut, String> {
 }
 
 fn display_shortcut_label(display: &DisplayState) -> String {
+    if let Some(number) = display_number(display) {
+        return format!("Display {number}");
+    }
+
     if display.is_primary {
         return "Primary display".to_string();
     }
@@ -275,11 +279,47 @@ fn display_shortcut_label(display: &DisplayState) -> String {
     }
 }
 
+fn display_number(display: &DisplayState) -> Option<usize> {
+    let upper_name = display.name.to_ascii_uppercase();
+    let marker_index = upper_name.find("DISPLAY")? + "DISPLAY".len();
+    let digits = upper_name[marker_index..]
+        .chars()
+        .take_while(|character| character.is_ascii_digit())
+        .collect::<String>();
+
+    if digits.is_empty() {
+        return None;
+    }
+
+    digits.parse::<usize>().ok()
+}
+
+fn next_available_default_slot(used_slots: &HashSet<usize>) -> Option<usize> {
+    (1..=MAX_DEFAULT_DISPLAY_BINDINGS).find(|slot| !used_slots.contains(slot))
+}
+
 fn default_initialized_settings(
     state: &SharedState,
     previous_settings: &AppSettings,
 ) -> Option<AppSettings> {
+    let ordered_displays = {
+        let state = state.lock().expect("state poisoned");
+        let mut displays = state.displays.values().cloned().collect::<Vec<_>>();
+        displays.sort_by_key(|display| (display.y, display.x));
+        displays
+    };
+    let legacy_shortcut_settings = build_legacy_default_shortcut_settings(&ordered_displays);
+    let next_shortcut_settings = build_default_shortcut_settings(&ordered_displays);
+
     if previous_settings.shortcut_defaults_initialized {
+        if previous_settings.shortcut_settings == legacy_shortcut_settings
+            && previous_settings.shortcut_settings != next_shortcut_settings
+        {
+            let mut next_settings = previous_settings.clone();
+            next_settings.shortcut_settings = next_shortcut_settings;
+            return Some(next_settings);
+        }
+
         return None;
     }
 
@@ -295,21 +335,48 @@ fn default_initialized_settings(
             .display_bindings
             .is_empty()
     {
+        if previous_settings.shortcut_settings == legacy_shortcut_settings
+            && previous_settings.shortcut_settings != next_shortcut_settings
+        {
+            next_settings.shortcut_settings = next_shortcut_settings;
+        }
+
         return Some(next_settings);
     }
 
-    let ordered_displays = {
-        let state = state.lock().expect("state poisoned");
-        let mut displays = state.displays.values().cloned().collect::<Vec<_>>();
-        displays.sort_by_key(|display| (display.y, display.x));
-        displays
-    };
-
-    next_settings.shortcut_settings = build_default_shortcut_settings(&ordered_displays);
+    next_settings.shortcut_settings = next_shortcut_settings;
     Some(next_settings)
 }
 
 fn build_default_shortcut_settings(displays: &[DisplayState]) -> ShortcutSettings {
+    let display_bindings = displays
+        .iter()
+        .scan(HashSet::<usize>::new(), |used_slots, display| {
+            let slot = display_number(display)
+                .filter(|slot| (1..=MAX_DEFAULT_DISPLAY_BINDINGS).contains(slot))
+                .filter(|slot| used_slots.insert(*slot))
+                .or_else(|| {
+                    let slot = next_available_default_slot(used_slots)?;
+                    used_slots.insert(slot);
+                    Some(slot)
+                });
+
+            Some(slot.map(|slot| DisplayHotkeyBinding {
+                display_key: display.persistent_key.clone(),
+                display_label: display_shortcut_label(display),
+                accelerator: format!("{DEFAULT_DISPLAY_ACCELERATOR_PREFIX}{slot}"),
+            }))
+        })
+        .flatten()
+        .collect();
+
+    ShortcutSettings {
+        focus_mode_hotkey: Some(DEFAULT_FOCUS_ACCELERATOR.to_string()),
+        display_bindings,
+    }
+}
+
+fn build_legacy_default_shortcut_settings(displays: &[DisplayState]) -> ShortcutSettings {
     let display_bindings = displays
         .iter()
         .take(MAX_DEFAULT_DISPLAY_BINDINGS)

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -1,0 +1,328 @@
+use std::collections::{HashMap, HashSet};
+
+use log::{info, warn};
+use tauri::AppHandle;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutEvent, ShortcutState};
+
+use crate::{
+    commands::{self, SharedState},
+    settings::{self, AppSettings, DisplayHotkeyBinding, ShortcutSettings},
+    state::{DisplayState, ShortcutAction},
+};
+
+struct PlannedShortcut {
+    accelerator: String,
+    shortcut: Shortcut,
+    action: ShortcutAction,
+}
+
+const DEFAULT_FOCUS_ACCELERATOR: &str = "Ctrl+Shift+Num0";
+const DEFAULT_DISPLAY_ACCELERATOR_PREFIX: &str = "Ctrl+Shift+Num";
+const MAX_DEFAULT_DISPLAY_BINDINGS: usize = 9;
+
+pub fn ensure_default_shortcuts(app: &AppHandle, state: &SharedState) -> Result<bool, String> {
+    let previous_settings = {
+        let state = state.lock().expect("state poisoned");
+        state.settings.clone()
+    };
+
+    let Some(next_settings) = default_initialized_settings(state, &previous_settings) else {
+        return Ok(false);
+    };
+
+    {
+        let mut state = state.lock().expect("state poisoned");
+        state.settings = next_settings.clone();
+    }
+
+    if let Err(error) = sync_registered_shortcuts(app, state) {
+        let mut locked_state = state.lock().expect("state poisoned");
+        locked_state.settings = previous_settings.clone();
+        drop(locked_state);
+        let _ = sync_registered_shortcuts(app, state);
+        return Err(error);
+    }
+
+    if let Err(error) = settings::save_settings(app, &next_settings) {
+        let mut locked_state = state.lock().expect("state poisoned");
+        locked_state.settings = previous_settings;
+        drop(locked_state);
+        let _ = sync_registered_shortcuts(app, state);
+        return Err(error);
+    }
+
+    Ok(true)
+}
+
+pub fn sanitize_shortcut_settings(
+    state: &SharedState,
+    shortcut_settings: ShortcutSettings,
+) -> Result<ShortcutSettings, String> {
+    let display_labels_by_key = {
+        let state = state.lock().expect("state poisoned");
+        state
+            .displays
+            .values()
+            .map(|display| {
+                (
+                    display.persistent_key.clone(),
+                    display_shortcut_label(display),
+                )
+            })
+            .collect::<HashMap<_, _>>()
+    };
+
+    let mut seen_shortcuts = HashMap::<u32, String>::new();
+    let mut seen_display_keys = HashSet::<String>::new();
+
+    let focus_mode_hotkey = shortcut_settings
+        .focus_mode_hotkey
+        .as_deref()
+        .map(parse_shortcut)
+        .transpose()?
+        .map(|shortcut| {
+            seen_shortcuts.insert(shortcut.id(), "Focus mode".to_string());
+            shortcut.to_string()
+        });
+
+    let mut display_bindings = Vec::new();
+
+    for binding in shortcut_settings.display_bindings {
+        let display_key = binding.display_key.trim();
+        if display_key.is_empty() {
+            continue;
+        }
+
+        if !seen_display_keys.insert(display_key.to_string()) {
+            return Err(format!(
+                "Only one shortcut can be stored for display {}.",
+                binding.display_label.trim()
+            ));
+        }
+
+        let accelerator = binding.accelerator.trim();
+        if accelerator.is_empty() {
+            continue;
+        }
+
+        let shortcut = parse_shortcut(accelerator)?;
+        let display_label = display_labels_by_key
+            .get(display_key)
+            .cloned()
+            .or_else(|| {
+                let label = binding.display_label.trim();
+                if label.is_empty() {
+                    None
+                } else {
+                    Some(label.to_string())
+                }
+            })
+            .unwrap_or_else(|| display_key.to_string());
+
+        if let Some(existing_owner) = seen_shortcuts.insert(shortcut.id(), display_label.clone()) {
+            return Err(format!(
+                "Shortcut {} is already used by {}.",
+                accelerator, existing_owner
+            ));
+        }
+
+        display_bindings.push(DisplayHotkeyBinding {
+            display_key: display_key.to_string(),
+            display_label,
+            accelerator: shortcut.to_string(),
+        });
+    }
+
+    Ok(ShortcutSettings {
+        focus_mode_hotkey,
+        display_bindings,
+    })
+}
+
+pub fn sync_registered_shortcuts(app: &AppHandle, state: &SharedState) -> Result<(), String> {
+    let planned_shortcuts = build_planned_shortcuts(state)?;
+
+    app.global_shortcut()
+        .unregister_all()
+        .map_err(|error| format!("Failed to clear existing shortcuts: {error}"))?;
+
+    let mut registered_shortcuts = HashMap::new();
+
+    for planned in &planned_shortcuts {
+        app.global_shortcut()
+            .register(planned.shortcut)
+            .map_err(|error| {
+                let _ = app.global_shortcut().unregister_all();
+                format!(
+                    "Failed to register shortcut {}: {error}",
+                    planned.accelerator
+                )
+            })?;
+
+        registered_shortcuts.insert(planned.shortcut.id(), planned.action.clone());
+    }
+
+    let mut locked_state = state.lock().expect("state poisoned");
+    locked_state.registered_shortcuts = registered_shortcuts;
+
+    info!(
+        "sync_registered_shortcuts: registered {} shortcut(s)",
+        planned_shortcuts.len()
+    );
+
+    Ok(())
+}
+
+pub fn handle_shortcut_event(
+    app: &AppHandle,
+    shortcut: &Shortcut,
+    event: ShortcutEvent,
+    state: &SharedState,
+) {
+    if event.state() != ShortcutState::Pressed {
+        return;
+    }
+
+    let Some(action) = ({
+        let state = state.lock().expect("state poisoned");
+        state.registered_shortcuts.get(&shortcut.id()).cloned()
+    }) else {
+        return;
+    };
+
+    if let Err(error) = commands::execute_shortcut_action(app, state, action) {
+        warn!(
+            "handle_shortcut_event: failed to run shortcut {}: {}",
+            shortcut, error
+        );
+    }
+}
+
+fn build_planned_shortcuts(state: &SharedState) -> Result<Vec<PlannedShortcut>, String> {
+    let (shortcut_settings, available_display_keys) = {
+        let state = state.lock().expect("state poisoned");
+        (
+            state.settings.shortcut_settings.clone(),
+            state
+                .displays
+                .values()
+                .map(|display| display.persistent_key.clone())
+                .collect::<HashSet<_>>(),
+        )
+    };
+
+    let mut planned_shortcuts = Vec::new();
+
+    if let Some(accelerator) = shortcut_settings.focus_mode_hotkey {
+        let shortcut = parse_shortcut(&accelerator)?;
+        planned_shortcuts.push(PlannedShortcut {
+            accelerator,
+            shortcut,
+            action: ShortcutAction::FocusMode,
+        });
+    }
+
+    for binding in shortcut_settings.display_bindings {
+        if !available_display_keys.contains(&binding.display_key) {
+            continue;
+        }
+
+        let shortcut = parse_shortcut(&binding.accelerator)?;
+        planned_shortcuts.push(PlannedShortcut {
+            accelerator: binding.accelerator,
+            shortcut,
+            action: ShortcutAction::ToggleDisplay {
+                display_key: binding.display_key,
+            },
+        });
+    }
+
+    Ok(planned_shortcuts)
+}
+
+fn parse_shortcut(raw: &str) -> Result<Shortcut, String> {
+    let accelerator = raw.trim();
+    let shortcut = accelerator
+        .parse::<Shortcut>()
+        .map_err(|error| format!("Invalid shortcut {accelerator:?}: {error}"))?;
+
+    if shortcut.mods.is_empty() {
+        return Err(format!(
+            "Shortcut {accelerator:?} must include at least one modifier key."
+        ));
+    }
+
+    Ok(shortcut)
+}
+
+fn display_shortcut_label(display: &DisplayState) -> String {
+    if display.is_primary {
+        return "Primary display".to_string();
+    }
+
+    let descriptor = [display.manufacturer.as_str(), display.model.as_str()]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if !descriptor.is_empty() {
+        descriptor
+    } else if !display.name.is_empty() {
+        display.name.clone()
+    } else {
+        "Display".to_string()
+    }
+}
+
+fn default_initialized_settings(
+    state: &SharedState,
+    previous_settings: &AppSettings,
+) -> Option<AppSettings> {
+    if previous_settings.shortcut_defaults_initialized {
+        return None;
+    }
+
+    let mut next_settings = previous_settings.clone();
+    next_settings.shortcut_defaults_initialized = true;
+
+    if previous_settings
+        .shortcut_settings
+        .focus_mode_hotkey
+        .is_some()
+        || !previous_settings
+            .shortcut_settings
+            .display_bindings
+            .is_empty()
+    {
+        return Some(next_settings);
+    }
+
+    let ordered_displays = {
+        let state = state.lock().expect("state poisoned");
+        let mut displays = state.displays.values().cloned().collect::<Vec<_>>();
+        displays.sort_by_key(|display| (display.y, display.x));
+        displays
+    };
+
+    next_settings.shortcut_settings = build_default_shortcut_settings(&ordered_displays);
+    Some(next_settings)
+}
+
+fn build_default_shortcut_settings(displays: &[DisplayState]) -> ShortcutSettings {
+    let display_bindings = displays
+        .iter()
+        .take(MAX_DEFAULT_DISPLAY_BINDINGS)
+        .enumerate()
+        .map(|(index, display)| DisplayHotkeyBinding {
+            display_key: display.persistent_key.clone(),
+            display_label: format!("Display {}", index + 1),
+            accelerator: format!("{DEFAULT_DISPLAY_ACCELERATOR_PREFIX}{}", index + 1),
+        })
+        .collect();
+
+    ShortcutSettings {
+        focus_mode_hotkey: Some(DEFAULT_FOCUS_ACCELERATOR.to_string()),
+        display_bindings,
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,3 @@
-
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -10,6 +9,7 @@ pub struct DisplayState {
     pub name: String,
     pub manufacturer: String,
     pub model: String,
+    pub persistent_key: String,
     pub width: u32,
     pub height: u32,
     pub x: i32,
@@ -35,6 +35,7 @@ pub struct DisplayInfo {
     pub name: String,
     pub manufacturer: String,
     pub model: String,
+    pub persistent_key: String,
     pub width: u32,
     pub height: u32,
     pub x: i32,
@@ -46,7 +47,30 @@ pub struct DisplayInfo {
     pub is_blacked_out: bool,
     pub hosts_panel: bool,
     pub can_blackout: bool,
+    pub hotkey: Option<String>,
     pub hidden_apps: Vec<HiddenAppSummary>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplayShortcutBindingInfo {
+    pub display_key: String,
+    pub display_label: String,
+    pub accelerator: String,
+    pub is_available: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShortcutSettingsPayload {
+    pub focus_mode_hotkey: Option<String>,
+    pub display_bindings: Vec<DisplayShortcutBindingInfo>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ShortcutAction {
+    FocusMode,
+    ToggleDisplay { display_key: String },
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -57,12 +81,14 @@ pub struct DisplayUpdatePayload {
     pub blackout_count: usize,
     pub allow_cursor_exit_active_displays: bool,
     pub show_overlay_hidden_apps: bool,
+    pub shortcut_settings: ShortcutSettingsPayload,
 }
 
 pub struct NocturnState {
     pub displays: HashMap<String, DisplayState>,
     pub settings: AppSettings,
     pub toggle_in_progress: bool,
+    pub registered_shortcuts: HashMap<u32, ShortcutAction>,
 }
 
 impl Default for NocturnState {
@@ -71,6 +97,7 @@ impl Default for NocturnState {
             displays: HashMap::new(),
             settings: AppSettings::default(),
             toggle_in_progress: false,
+            registered_shortcuts: HashMap::new(),
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Nocturn",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.hugolannes.nocturn",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -17,6 +17,7 @@
         "width": 720,
         "height": 520,
         "resizable": false,
+        "maximizable": false,
         "fullscreen": false,
         "visible": true,
         "decorations": false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,7 @@ function App() {
     allowCursorExitActiveDisplays,
     showOverlayHiddenApps,
     shortcutSettings,
+    resetToDefaults,
     setAllowCursorExitActiveDisplays,
     setShowOverlayHiddenApps,
     setShortcutSettings,
@@ -183,13 +184,20 @@ function App() {
         data-tauri-drag-region
       >
         <div className="flex items-center gap-[10px]">
-          <img src={appLogo} alt="Nocturn logo" className="h-7 w-7 object-contain" style={titlebarLogoStyle} />
-          <span
-            className="inline-flex items-center bg-[linear-gradient(180deg,#ffffff_0%,var(--accent-soft)_100%)] bg-clip-text text-[16px] font-bold leading-none tracking-[-0.055em] text-transparent [-webkit-text-fill-color:transparent]"
-            style={titlebarNameStyle}
+          <button
+            type="button"
+            className="group flex items-center gap-[10px] rounded-[8px] border-0 bg-transparent p-0 [-webkit-app-region:no-drag] [app-region:no-drag]"
+            onClick={() => setActiveView("displays")}
+            title="Back to displays"
           >
-            Nocturn
-          </span>
+            <img src={appLogo} alt="Nocturn logo" className="h-7 w-7 object-contain transition-[filter] duration-[160ms] ease-out group-hover:[filter:drop-shadow(0_0_10px_rgba(var(--accent-rgb),0.9))_drop-shadow(0_0_22px_rgba(var(--accent-rgb),0.6))]" style={titlebarLogoStyle} />
+            <span
+              className="inline-flex items-center bg-[linear-gradient(180deg,#ffffff_0%,var(--accent-soft)_100%)] bg-clip-text text-[16px] font-bold leading-none tracking-[-0.055em] text-transparent transition-[filter] duration-[160ms] ease-out [-webkit-text-fill-color:transparent] group-hover:[filter:drop-shadow(0_0_8px_rgba(var(--accent-rgb),0.7))]"
+              style={titlebarNameStyle}
+            >
+              Nocturn
+            </span>
+          </button>
           <span className="flex items-center gap-[5px] rounded-full border border-white/6 bg-white/5 px-2 py-[3px] pl-[6px]">
             <span className="h-[5px] w-[5px] rounded-full bg-[var(--dot-on)] shadow-[0_0_6px_var(--glow-on)]" />
             <span className="whitespace-nowrap text-[11px] font-medium tracking-[0.01em] text-[var(--text-secondary)]">{appVersion}</span>
@@ -283,6 +291,7 @@ function App() {
             onUpdateShortcutSettings={setShortcutSettings}
             onToggleAllowCursorExitActiveDisplays={(allowed) => void setAllowCursorExitActiveDisplays(allowed)}
             onToggleShowOverlayHiddenApps={(enabled) => void setShowOverlayHiddenApps(enabled)}
+            onResetToDefaults={() => void resetToDefaults()}
           />
         ) : (
           <DisplayLayout

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ function wakeButtonClass(isActive: boolean) {
 }
 
 function App() {
-  const appVersion = `v${packageInfo.version}`;
+  const appVersion = packageInfo.version;
   const {
     displays,
     isLoading,
@@ -180,7 +180,7 @@ function App() {
       )}
 
       <header
-        className="flex h-11 shrink-0 items-center justify-between border-b border-[var(--border)] pl-[14px] pr-[10px] [-webkit-app-region:drag] [app-region:drag]"
+        className="flex h-11 shrink-0 select-none items-center justify-between border-b border-[var(--border)] pl-[14px] pr-[10px] [-webkit-app-region:drag] [app-region:drag]"
         data-tauri-drag-region
       >
         <div className="flex items-center gap-[10px]">
@@ -192,15 +192,17 @@ function App() {
           >
             <img src={appLogo} alt="Nocturn logo" className="h-7 w-7 object-contain transition-[filter] duration-[160ms] ease-out group-hover:[filter:drop-shadow(0_0_10px_rgba(var(--accent-rgb),0.9))_drop-shadow(0_0_22px_rgba(var(--accent-rgb),0.6))]" style={titlebarLogoStyle} />
             <span
-              className="inline-flex items-center bg-[linear-gradient(180deg,#ffffff_0%,var(--accent-soft)_100%)] bg-clip-text text-[16px] font-bold leading-none tracking-[-0.055em] text-transparent transition-[filter] duration-[160ms] ease-out [-webkit-text-fill-color:transparent] group-hover:[filter:drop-shadow(0_0_8px_rgba(var(--accent-rgb),0.7))]"
+              className="inline-flex items-center bg-[linear-gradient(180deg,#ffffff_0%,var(--accent-soft)_100%)] bg-clip-text text-[17px] font-bold leading-none tracking-[-0.055em] text-transparent transition-[filter] duration-[160ms] ease-out [-webkit-text-fill-color:transparent] group-hover:[filter:drop-shadow(0_0_8px_rgba(var(--accent-rgb),0.7))] max-[560px]:text-[16px]"
               style={titlebarNameStyle}
             >
               Nocturn
             </span>
           </button>
-          <span className="flex items-center gap-[5px] rounded-full border border-white/6 bg-white/5 px-2 py-[3px] pl-[6px]">
-            <span className="h-[5px] w-[5px] rounded-full bg-[var(--dot-on)] shadow-[0_0_6px_var(--glow-on)]" />
-            <span className="whitespace-nowrap text-[11px] font-medium tracking-[0.01em] text-[var(--text-secondary)]">{appVersion}</span>
+          <span
+            className="whitespace-nowrap self-end pb-[2px] text-[11px] font-medium tracking-[0.04em] text-[rgba(241,245,249,0.72)]"
+            style={monoTextStyle}
+          >
+            {appVersion}
           </span>
         </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,8 +86,10 @@ function App() {
     focusPrimary,
     allowCursorExitActiveDisplays,
     showOverlayHiddenApps,
+    shortcutSettings,
     setAllowCursorExitActiveDisplays,
     setShowOverlayHiddenApps,
+    setShortcutSettings,
     lastActiveDisplayId,
   } = useDisplays();
   const {
@@ -273,9 +275,12 @@ function App() {
       <main className="min-h-0 flex-1 overflow-hidden px-4 pb-3 pt-[14px] max-[560px]:px-3 max-[560px]:pb-[10px] max-[560px]:pt-3">
         {activeView === "settings" ? (
           <SettingsPage
+            displays={displays}
+            shortcutSettings={shortcutSettings}
             allowCursorExitActiveDisplays={allowCursorExitActiveDisplays}
             showOverlayHiddenApps={showOverlayHiddenApps}
             isMutating={isMutating}
+            onUpdateShortcutSettings={setShortcutSettings}
             onToggleAllowCursorExitActiveDisplays={(allowed) => void setAllowCursorExitActiveDisplays(allowed)}
             onToggleShowOverlayHiddenApps={(enabled) => void setShowOverlayHiddenApps(enabled)}
           />
@@ -286,6 +291,7 @@ function App() {
             isMutating={isMutating}
             pendingDisplayIds={pendingDisplayIds}
             lastActiveDisplayId={lastActiveDisplayId}
+            focusModeHotkey={shortcutSettings.focusModeHotkey}
             onFocusMode={() => void focusPrimary()}
             onToggle={(id) => void toggleDisplay(id)}
           />

--- a/src/components/DisplayLayout.tsx
+++ b/src/components/DisplayLayout.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { formatShortcutForDisplay } from "../shortcuts";
 import type { Display } from "../types";
+import { ShortcutKeycaps } from "./ShortcutKeycaps";
 import {
   cn,
   layoutEyebrowClass,
@@ -154,8 +155,11 @@ export function DisplayLayout({
           aria-label="Enable focus mode and keep only the primary display active"
         >
           <span className="text-[14px] font-semibold leading-[1.05] tracking-[-0.03em]">Focus mode</span>
-          <span className="text-[10px] uppercase leading-[1.2] tracking-[0.08em] text-[rgba(226,232,240,0.64)]" style={monoTextStyle}>
-            {focusModeHotkey ? `Primary only · ${formatShortcutForDisplay(focusModeHotkey)}` : "Primary only"}
+          <span className="flex flex-wrap items-center gap-x-[6px] gap-y-[4px]">
+            <span className="text-[10px] uppercase leading-[1.2] tracking-[0.08em] text-[rgba(226,232,240,0.64)]" style={monoTextStyle}>
+              Primary only
+            </span>
+            <ShortcutKeycaps accelerator={focusModeHotkey} size="sm" />
           </span>
         </button>
       </header>
@@ -170,6 +174,7 @@ export function DisplayLayout({
           {displays.map((display, index) => {
             const isLastActive = lastActiveDisplayId === display.id && !display.isBlackedOut;
             const isPending = pendingDisplayIds.has(display.id);
+            const shortcutLabel = formatShortcutForDisplay(display.hotkey);
             // isMutating is only true during global ops (focus mode, restore all).
             // Individual card toggles use per-card isPending so other cards stay interactive.
             const isDisabled = isMutating || isPending || isLastActive || !display.canBlackout;
@@ -202,9 +207,9 @@ export function DisplayLayout({
                 style={displayCardStyle(display, isPending, left, top, width, height)}
                 onClick={() => onToggle(display.id)}
                 disabled={isDisabled}
-                aria-label={`${cleanName(display.name)} at ${display.width}x${display.height}`}
+                aria-label={`${cleanName(display.name)} at ${display.width}x${display.height}${shortcutLabel ? `, shortcut ${shortcutLabel}` : ""}`}
                 aria-busy={isPending}
-                title={`${cleanName(display.name)} • ${display.width}x${display.height} • ${display.x}, ${display.y}${display.hotkey ? ` • ${formatShortcutForDisplay(display.hotkey)}` : ""}`}
+                title={`${cleanName(display.name)} • ${display.width}x${display.height} • ${display.x}, ${display.y}${shortcutLabel ? ` • ${shortcutLabel}` : ""}`}
               >
                 <span className={cn("flex items-center justify-between gap-[5px]", isTiny && "items-start")}>
                   <span className={cn(layoutEyebrowClass, eyebrowSizeClass)} style={monoTextStyle}>
@@ -225,7 +230,7 @@ export function DisplayLayout({
                   <span className={cn("max-w-full overflow-hidden text-ellipsis whitespace-nowrap font-bold leading-[1.05] tracking-[-0.035em]", nameSizeClass)}>
                     {displayTitle(display)}
                   </span>
-                  {!isTiny ? (
+                  {!isTiny && (!isCompact || !shortcutLabel) ? (
                     <span
                       className={cn(
                         "overflow-hidden leading-[1.35] text-[rgba(226,232,240,0.72)]",
@@ -234,6 +239,13 @@ export function DisplayLayout({
                     >
                       {displaySummary(display)}
                     </span>
+                  ) : null}
+                  {shortcutLabel ? (
+                    <ShortcutKeycaps
+                      accelerator={display.hotkey}
+                      size={isTiny || isCompact ? "xs" : "sm"}
+                      className="max-w-full"
+                    />
                   ) : null}
                 </span>
 

--- a/src/components/DisplayLayout.tsx
+++ b/src/components/DisplayLayout.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { formatShortcutForDisplay } from "../shortcuts";
 import type { Display } from "../types";
 import {
   cn,
@@ -13,6 +14,7 @@ type DisplayLayoutProps = {
   isMutating: boolean;
   pendingDisplayIds: ReadonlySet<string>;
   lastActiveDisplayId: string | null;
+  focusModeHotkey: string | null;
   onFocusMode: () => void;
   onToggle: (displayId: string) => void;
 };
@@ -112,6 +114,7 @@ export function DisplayLayout({
   isMutating,
   pendingDisplayIds,
   lastActiveDisplayId,
+  focusModeHotkey,
   onFocusMode,
   onToggle,
 }: DisplayLayoutProps) {
@@ -152,7 +155,7 @@ export function DisplayLayout({
         >
           <span className="text-[14px] font-semibold leading-[1.05] tracking-[-0.03em]">Focus mode</span>
           <span className="text-[10px] uppercase leading-[1.2] tracking-[0.08em] text-[rgba(226,232,240,0.64)]" style={monoTextStyle}>
-            Primary only
+            {focusModeHotkey ? `Primary only · ${formatShortcutForDisplay(focusModeHotkey)}` : "Primary only"}
           </span>
         </button>
       </header>
@@ -201,7 +204,7 @@ export function DisplayLayout({
                 disabled={isDisabled}
                 aria-label={`${cleanName(display.name)} at ${display.width}x${display.height}`}
                 aria-busy={isPending}
-                title={`${cleanName(display.name)} • ${display.width}x${display.height} • ${display.x}, ${display.y}`}
+                title={`${cleanName(display.name)} • ${display.width}x${display.height} • ${display.x}, ${display.y}${display.hotkey ? ` • ${formatShortcutForDisplay(display.hotkey)}` : ""}`}
               >
                 <span className={cn("flex items-center justify-between gap-[5px]", isTiny && "items-start")}>
                   <span className={cn(layoutEyebrowClass, eyebrowSizeClass)} style={monoTextStyle}>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -27,13 +27,19 @@ const settingsCardClass = "rounded-[18px] border border-[var(--border)] px-[18px
 const settingsRowClass = "flex items-center justify-between gap-[22px] border-t border-white/6 pt-4 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:gap-[14px] max-[560px]:pt-[14px]";
 
 function displayShortcutTitle(display: Display, index: number) {
+  const match = display.name.match(/DISPLAY(\d+)/i);
+  if (match) {
+    return `Display ${match[1]}`;
+  }
+
   return display.isPrimary ? "Primary display" : `Display ${index + 1}`;
 }
 
 function displayShortcutHint(display: Display) {
   const descriptor = [display.manufacturer, display.model].filter(Boolean).join(" ");
   const meta = `${display.width}x${display.height}`;
-  return descriptor ? `${descriptor} · ${meta}` : meta;
+  const details = descriptor ? `${descriptor} · ${meta}` : meta;
+  return display.isPrimary ? `Primary · ${details}` : details;
 }
 
 function toShortcutSettingsInput(shortcutSettings: ShortcutSettings): ShortcutSettingsInput {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Display, ShortcutSettings, ShortcutSettingsInput } from "../types";
 import { cn, layoutEyebrowClass, layoutTitleClass, monoTextStyle } from "../ui";
 import { ShortcutField } from "./ShortcutField";
@@ -13,9 +14,14 @@ type SettingsPageProps = {
   onToggleShowOverlayHiddenApps: (enabled: boolean) => void;
 };
 
-type SettingsToggleCardProps = {
+type SettingsSectionProps = {
+  eyebrow: string;
   title: string;
-  label: string;
+  children: ReactNode;
+};
+
+type SettingsToggleRowProps = {
+  title: string;
   hint: string;
   ariaLabel: string;
   enabled: boolean;
@@ -23,8 +29,10 @@ type SettingsToggleCardProps = {
   onToggle: () => void;
 };
 
-const settingsCardClass = "rounded-[18px] border border-[var(--border)] px-[18px] pb-4 pt-[18px] max-[560px]:p-4 [background:linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.015)),rgba(255,255,255,0.02)]";
-const settingsRowClass = "flex items-center justify-between gap-[22px] border-t border-white/6 pt-4 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:gap-[14px] max-[560px]:pt-[14px]";
+const sectionClass = "rounded-[20px] border border-[var(--border)] px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_18px_40px_rgba(2,6,23,0.16)] [background:linear-gradient(180deg,rgba(255,255,255,0.036),rgba(255,255,255,0.018)_42%,rgba(255,255,255,0.022))] max-[560px]:px-4 max-[560px]:py-3.5";
+const rowClass = "flex items-center justify-between gap-4 py-2.5 max-[560px]:py-2";
+const dividerClass = "border-t border-white/[0.065]";
+const groupLabelClass = "inline-block pt-2.5 pb-1 text-[11px] uppercase tracking-[0.08em] text-[rgba(226,232,240,0.44)]";
 
 function displayShortcutTitle(display: Display, index: number) {
   const match = display.name.match(/DISPLAY(\d+)/i);
@@ -53,53 +61,59 @@ function toShortcutSettingsInput(shortcutSettings: ShortcutSettings): ShortcutSe
   };
 }
 
-function SettingsToggleCard({
+function SettingsSection({ eyebrow, title, children }: SettingsSectionProps) {
+  return (
+    <article className={sectionClass}>
+      <div className="flex items-baseline gap-2 pb-2">
+        <span className={layoutEyebrowClass} style={monoTextStyle}>{eyebrow}</span>
+        <h2 className="text-[15px] font-semibold leading-none tracking-[-0.03em] text-[var(--accent-soft)] max-[560px]:text-[14px]">
+          {title}
+        </h2>
+      </div>
+      <div className={dividerClass}>{children}</div>
+    </article>
+  );
+}
+
+function SettingsToggleRow({
   title,
-  label,
   hint,
   ariaLabel,
   enabled,
   disabled,
   onToggle,
-}: SettingsToggleCardProps) {
+}: SettingsToggleRowProps) {
   return (
-    <article className={settingsCardClass}>
-      <div className="flex items-center justify-between gap-[22px] pb-4 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:gap-3 max-[560px]:pb-[14px]">
-        <div>
-          <h2 className="text-[22px] font-semibold leading-none tracking-[0.02em] text-[var(--accent-soft)]">{title}</h2>
-        </div>
+    <div className={rowClass}>
+      <div className="min-w-0">
+        <span className="text-[14px] font-semibold leading-[1.15] tracking-[-0.02em] text-[var(--text-primary)]">{title}</span>
+        <p className="mt-0.5 text-[12px] leading-[1.5] text-[rgba(226,232,240,0.56)]">{hint}</p>
       </div>
 
-      <label className={settingsRowClass}>
-        <div>
-          <span className="block text-[14px] font-semibold leading-[1.15]">{label}</span>
-          <p className="mt-1.5 max-w-[560px] text-[13px] leading-[1.6] text-[rgba(226,232,240,0.66)]">
-            {hint}
-          </p>
-        </div>
-
-        <button
-          type="button"
+      <button
+        type="button"
+        role="switch"
+        className={cn(
+          "relative h-5 w-9 shrink-0 rounded-full border transition-[background,border-color,box-shadow] duration-[140ms] ease-out disabled:cursor-not-allowed disabled:opacity-50",
+          enabled
+            ? "border-[rgba(var(--accent-rgb),0.34)] bg-[linear-gradient(90deg,rgba(var(--accent-rgb),0.94),rgba(var(--accent-rgb),0.62))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_4px_12px_rgba(var(--accent-rgb),0.22)]"
+            : "border-white/10 bg-[rgba(148,163,184,0.12)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] hover:bg-[rgba(148,163,184,0.20)]",
+        )}
+        onClick={onToggle}
+        aria-label={ariaLabel}
+        aria-checked={enabled}
+        disabled={disabled}
+      >
+        <span
           className={cn(
-            "flex h-8 w-[58px] shrink-0 items-center rounded-full border-0 p-1 transition-[background,box-shadow] duration-[140ms] ease-out disabled:cursor-not-allowed disabled:opacity-50 max-[560px]:w-[52px]",
+            "block h-3.5 w-3.5 rounded-full transition-transform duration-[140ms] ease-out",
             enabled
-              ? "bg-[linear-gradient(90deg,rgba(var(--accent-rgb),0.94),rgba(var(--accent-rgb),0.76))] shadow-[inset_0_0_0_1px_rgba(var(--accent-rgb),0.24),0_4px_18px_rgba(var(--accent-rgb),0.28)] hover:shadow-[inset_0_0_0_1px_rgba(var(--accent-rgb),0.24),0_4px_18px_rgba(var(--accent-rgb),0.34)]"
-              : "bg-[rgba(148,163,184,0.16)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)] hover:bg-[rgba(148,163,184,0.22)]",
+              ? "translate-x-[17px] bg-white shadow-[0_1px_4px_rgba(15,23,42,0.3)]"
+              : "translate-x-[3px] bg-[rgba(148,163,184,0.55)] shadow-[0_1px_3px_rgba(15,23,42,0.2)]",
           )}
-          onClick={onToggle}
-          aria-label={ariaLabel}
-          aria-pressed={enabled}
-          disabled={disabled}
-        >
-          <span
-            className={cn(
-              "h-[22px] w-[22px] rounded-full bg-[#e2e8f0] shadow-[0_4px_12px_rgba(15,23,42,0.25)] transition-transform duration-[140ms] ease-out",
-              enabled && "translate-x-[26px]",
-            )}
-          />
-        </button>
-      </label>
-    </article>
+        />
+      </button>
+    </div>
   );
 }
 
@@ -123,82 +137,87 @@ export function SettingsPage({
 
   return (
     <section className="flex h-full min-h-0 flex-col gap-3" aria-label="Settings">
-      <header className="flex flex-col gap-[3px] px-[2px] pt-[2px] max-[560px]:items-stretch">
+      <header className="shrink-0 px-[2px] pt-[2px]">
         <span className={layoutEyebrowClass} style={monoTextStyle}>Settings</span>
         <h1 className={layoutTitleClass}>Set things your way.</h1>
       </header>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-[2px] pb-[6px] pt-[2px] max-[560px]:gap-[10px] max-[560px]:pr-0">
-        <SettingsToggleCard
-          title="Overlays"
-          label="Show hidden apps"
-          hint="Display the app names detected behind blackout overlays. Turn this off for a fully plain black screen."
-          ariaLabel="Show hidden apps on blackout overlays"
-          enabled={showOverlayHiddenApps}
-          disabled={isMutating}
-          onToggle={() => onToggleShowOverlayHiddenApps(!showOverlayHiddenApps)}
-        />
-
-        <SettingsToggleCard
-          title="Cursor"
-          label="Cursor freedom"
-          hint="Turn this on to let the mouse travel outside the active monitors. Turn it off to confine the pointer."
-          ariaLabel="Allow mouse to leave active displays"
-          enabled={allowCursorExitActiveDisplays}
-          disabled={isMutating}
-          onToggle={() => onToggleAllowCursorExitActiveDisplays(!allowCursorExitActiveDisplays)}
-        />
-
-        <article className={settingsCardClass}>
-          <div className="flex flex-col gap-1 pb-4 max-[560px]:pb-[14px]">
-            <h2 className="text-[22px] font-semibold leading-none tracking-[0.02em] text-[var(--accent-soft)]">Hotkeys</h2>
-            <p className="max-w-[620px] text-[13px] leading-[1.6] text-[rgba(226,232,240,0.66)]">
-              Set global shortcuts for Focus mode and each display. They keep working while Nocturn is minimized.
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-3 border-t border-white/6 pt-4 max-[560px]:pt-[14px]">
-            <ShortcutField
-              title="Focus mode"
-              hint="Keep only the primary display active."
-              value={shortcutSettings.focusModeHotkey}
+      <div className="nocturn-scrollbar min-h-0 flex-1 overflow-y-auto px-[2px] pb-[6px] pr-1.5 pt-[2px] max-[560px]:pr-0.5">
+        <div className="flex flex-col gap-3">
+          <SettingsSection eyebrow="General" title="Display and cursor">
+            <SettingsToggleRow
+              title="Show app names on overlays"
+              hint="Display detected app names behind blackout overlays."
+              ariaLabel="Show hidden apps on blackout overlays"
+              enabled={showOverlayHiddenApps}
               disabled={isMutating}
-              onSubmit={(accelerator) => updateShortcutSettings((draft) => {
-                draft.focusModeHotkey = accelerator;
-              })}
+              onToggle={() => onToggleShowOverlayHiddenApps(!showOverlayHiddenApps)}
             />
+            <div className={dividerClass}>
+              <SettingsToggleRow
+                title="Free cursor movement"
+                hint="Let the pointer travel outside active monitors."
+                ariaLabel="Allow mouse to leave active displays"
+                enabled={allowCursorExitActiveDisplays}
+                disabled={isMutating}
+                onToggle={() => onToggleAllowCursorExitActiveDisplays(!allowCursorExitActiveDisplays)}
+              />
+            </div>
+          </SettingsSection>
 
-            {displays.map((display, index) => (
+          <SettingsSection eyebrow="Keyboard control" title="Hotkeys">
+            <div className="py-1">
               <ShortcutField
-                key={display.persistentKey}
-                title={displayShortcutTitle(display, index)}
-                hint={displayShortcutHint(display)}
-                value={display.hotkey}
+                title="Focus mode"
+                hint="Primary only"
+                value={shortcutSettings.focusModeHotkey}
                 disabled={isMutating}
                 onSubmit={(accelerator) => updateShortcutSettings((draft) => {
-                  draft.displayBindings = draft.displayBindings.filter(
-                    (binding) => binding.displayKey !== display.persistentKey,
-                  );
-
-                  if (accelerator) {
-                    draft.displayBindings.push({
-                      displayKey: display.persistentKey,
-                      displayLabel: displayShortcutTitle(display, index),
-                      accelerator,
-                    });
-                  }
+                  draft.focusModeHotkey = accelerator;
                 })}
               />
-            ))}
+            </div>
+
+            {displays.length > 0 ? (
+              <div className={dividerClass}>
+                <span className={groupLabelClass} style={monoTextStyle}>
+                  Connected displays
+                </span>
+                {displays.map((display, index) => (
+                  <ShortcutField
+                    key={display.persistentKey}
+                    title={displayShortcutTitle(display, index)}
+                    hint={displayShortcutHint(display)}
+                    value={display.hotkey}
+                    disabled={isMutating}
+                    onSubmit={(accelerator) => updateShortcutSettings((draft) => {
+                      draft.displayBindings = draft.displayBindings.filter(
+                        (binding) => binding.displayKey !== display.persistentKey,
+                      );
+
+                      if (accelerator) {
+                        draft.displayBindings.push({
+                          displayKey: display.persistentKey,
+                          displayLabel: displayShortcutTitle(display, index),
+                          accelerator,
+                        });
+                      }
+                    })}
+                  />
+                ))}
+              </div>
+            ) : null}
 
             {unavailableBindings.length > 0 ? (
-              <div className="flex flex-col gap-3 pt-1">
-                <span className={layoutEyebrowClass} style={monoTextStyle}>Unavailable displays</span>
+              <div className={dividerClass}>
+                <span className={cn(groupLabelClass, "text-[rgba(226,232,240,0.38)]")} style={monoTextStyle}>
+                  Unavailable
+                </span>
                 {unavailableBindings.map((binding) => (
                   <ShortcutField
                     key={binding.displayKey}
                     title={binding.displayLabel}
-                    hint="This display is not currently connected. The shortcut is kept until you clear it."
+                    hint="Disconnected"
                     value={binding.accelerator}
                     disabled={isMutating}
                     statusText="Not available"
@@ -219,8 +238,8 @@ export function SettingsPage({
                 ))}
               </div>
             ) : null}
-          </div>
-        </article>
+          </SettingsSection>
+        </div>
       </div>
     </section>
   );

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,9 +1,14 @@
+import type { Display, ShortcutSettings, ShortcutSettingsInput } from "../types";
 import { cn, layoutEyebrowClass, layoutTitleClass, monoTextStyle } from "../ui";
+import { ShortcutField } from "./ShortcutField";
 
 type SettingsPageProps = {
+  displays: Display[];
+  shortcutSettings: ShortcutSettings;
   allowCursorExitActiveDisplays: boolean;
   showOverlayHiddenApps: boolean;
   isMutating: boolean;
+  onUpdateShortcutSettings: (settings: ShortcutSettingsInput) => Promise<string | null>;
   onToggleAllowCursorExitActiveDisplays: (allowed: boolean) => void;
   onToggleShowOverlayHiddenApps: (enabled: boolean) => void;
 };
@@ -20,6 +25,27 @@ type SettingsToggleCardProps = {
 
 const settingsCardClass = "rounded-[18px] border border-[var(--border)] px-[18px] pb-4 pt-[18px] max-[560px]:p-4 [background:linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.015)),rgba(255,255,255,0.02)]";
 const settingsRowClass = "flex items-center justify-between gap-[22px] border-t border-white/6 pt-4 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:gap-[14px] max-[560px]:pt-[14px]";
+
+function displayShortcutTitle(display: Display, index: number) {
+  return display.isPrimary ? "Primary display" : `Display ${index + 1}`;
+}
+
+function displayShortcutHint(display: Display) {
+  const descriptor = [display.manufacturer, display.model].filter(Boolean).join(" ");
+  const meta = `${display.width}x${display.height}`;
+  return descriptor ? `${descriptor} · ${meta}` : meta;
+}
+
+function toShortcutSettingsInput(shortcutSettings: ShortcutSettings): ShortcutSettingsInput {
+  return {
+    focusModeHotkey: shortcutSettings.focusModeHotkey,
+    displayBindings: shortcutSettings.displayBindings.map(({ displayKey, displayLabel, accelerator }) => ({
+      displayKey,
+      displayLabel,
+      accelerator,
+    })),
+  };
+}
 
 function SettingsToggleCard({
   title,
@@ -72,12 +98,23 @@ function SettingsToggleCard({
 }
 
 export function SettingsPage({
+  displays,
+  shortcutSettings,
   allowCursorExitActiveDisplays,
   showOverlayHiddenApps,
   isMutating,
+  onUpdateShortcutSettings,
   onToggleAllowCursorExitActiveDisplays,
   onToggleShowOverlayHiddenApps,
 }: SettingsPageProps) {
+  const unavailableBindings = shortcutSettings.displayBindings.filter((binding) => !binding.isAvailable);
+
+  async function updateShortcutSettings(mutator: (draft: ShortcutSettingsInput) => void) {
+    const nextSettings = toShortcutSettingsInput(shortcutSettings);
+    mutator(nextSettings);
+    return onUpdateShortcutSettings(nextSettings);
+  }
+
   return (
     <section className="flex h-full min-h-0 flex-col gap-3" aria-label="Settings">
       <header className="flex flex-col gap-[3px] px-[2px] pt-[2px] max-[560px]:items-stretch">
@@ -105,6 +142,79 @@ export function SettingsPage({
           disabled={isMutating}
           onToggle={() => onToggleAllowCursorExitActiveDisplays(!allowCursorExitActiveDisplays)}
         />
+
+        <article className={settingsCardClass}>
+          <div className="flex flex-col gap-1 pb-4 max-[560px]:pb-[14px]">
+            <h2 className="text-[22px] font-semibold leading-none tracking-[0.02em] text-[var(--accent-soft)]">Hotkeys</h2>
+            <p className="max-w-[620px] text-[13px] leading-[1.6] text-[rgba(226,232,240,0.66)]">
+              Set global shortcuts for Focus mode and each display. They keep working while Nocturn is minimized.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 border-t border-white/6 pt-4 max-[560px]:pt-[14px]">
+            <ShortcutField
+              title="Focus mode"
+              hint="Keep only the primary display active."
+              value={shortcutSettings.focusModeHotkey}
+              disabled={isMutating}
+              onSubmit={(accelerator) => updateShortcutSettings((draft) => {
+                draft.focusModeHotkey = accelerator;
+              })}
+            />
+
+            {displays.map((display, index) => (
+              <ShortcutField
+                key={display.persistentKey}
+                title={displayShortcutTitle(display, index)}
+                hint={displayShortcutHint(display)}
+                value={display.hotkey}
+                disabled={isMutating}
+                onSubmit={(accelerator) => updateShortcutSettings((draft) => {
+                  draft.displayBindings = draft.displayBindings.filter(
+                    (binding) => binding.displayKey !== display.persistentKey,
+                  );
+
+                  if (accelerator) {
+                    draft.displayBindings.push({
+                      displayKey: display.persistentKey,
+                      displayLabel: displayShortcutTitle(display, index),
+                      accelerator,
+                    });
+                  }
+                })}
+              />
+            ))}
+
+            {unavailableBindings.length > 0 ? (
+              <div className="flex flex-col gap-3 pt-1">
+                <span className={layoutEyebrowClass} style={monoTextStyle}>Unavailable displays</span>
+                {unavailableBindings.map((binding) => (
+                  <ShortcutField
+                    key={binding.displayKey}
+                    title={binding.displayLabel}
+                    hint="This display is not currently connected. The shortcut is kept until you clear it."
+                    value={binding.accelerator}
+                    disabled={isMutating}
+                    statusText="Not available"
+                    onSubmit={(accelerator) => updateShortcutSettings((draft) => {
+                      draft.displayBindings = draft.displayBindings.filter(
+                        (item) => item.displayKey !== binding.displayKey,
+                      );
+
+                      if (accelerator) {
+                        draft.displayBindings.push({
+                          displayKey: binding.displayKey,
+                          displayLabel: binding.displayLabel,
+                          accelerator,
+                        });
+                      }
+                    })}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </article>
       </div>
     </section>
   );

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -146,8 +146,8 @@ export function SettingsPage({
         <div className="flex flex-col gap-3">
           <SettingsSection eyebrow="General" title="Display and cursor">
             <SettingsToggleRow
-              title="Show app names on overlays"
-              hint="Display detected app names behind blackout overlays."
+              title="Show hidden apps on overlays"
+              hint="Display apps opened behind blackout overlays."
               ariaLabel="Show hidden apps on blackout overlays"
               enabled={showOverlayHiddenApps}
               disabled={isMutating}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -35,6 +35,15 @@ const rowClass = "flex items-center justify-between gap-4 py-2.5 max-[560px]:py-
 const dividerClass = "border-t border-white/[0.065]";
 const groupLabelClass = "inline-block pt-2.5 pb-1 text-[11px] uppercase tracking-[0.08em] text-[rgba(226,232,240,0.44)]";
 
+function resetButtonClass(isConfirming: boolean) {
+  return cn(
+    "relative mb-[2px] inline-flex items-center justify-center whitespace-nowrap rounded-[14px] border px-[12px] py-[5px] text-[13px] font-semibold leading-[1.05] tracking-[-0.03em] transition-[border-color,background,color,box-shadow,transform,opacity] duration-[140ms] ease-out enabled:hover:-translate-y-px disabled:cursor-not-allowed disabled:opacity-40 max-[560px]:rounded-[12px] max-[560px]:px-3 max-[560px]:py-[4px] max-[560px]:text-[12px]",
+    isConfirming
+      ? "border-[rgba(248,113,113,0.32)] text-[rgba(255,228,230,0.96)] [background:linear-gradient(180deg,rgba(248,113,113,0.22),rgba(248,113,113,0.08)_58%),rgba(255,255,255,0.04)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_10px_28px_rgba(127,29,29,0.22)] enabled:hover:border-[rgba(248,113,113,0.42)] enabled:hover:[background:linear-gradient(180deg,rgba(248,113,113,0.28),rgba(248,113,113,0.12)_58%),rgba(255,255,255,0.04)] enabled:hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_8px_24px_rgba(127,29,29,0.2)]"
+      : "border-white/10 text-[rgba(226,232,240,0.6)] [background:linear-gradient(180deg,rgba(var(--accent-rgb),0.14),rgba(255,255,255,0.03)_46%),rgba(255,255,255,0.03)] enabled:hover:border-[rgba(var(--accent-rgb),0.34)] enabled:hover:text-[rgba(226,232,240,0.78)] enabled:hover:[background:linear-gradient(180deg,rgba(var(--accent-rgb),0.2),rgba(255,255,255,0.04)_46%),rgba(255,255,255,0.04)] enabled:hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_24px_rgba(var(--accent-rgb),0.18)]",
+  );
+}
+
 function displayShortcutTitle(display: Display, index: number) {
   const match = display.name.match(/DISPLAY(\d+)/i);
   if (match) {
@@ -131,6 +140,7 @@ export function SettingsPage({
 }: SettingsPageProps) {
   const unavailableBindings = shortcutSettings.displayBindings.filter((binding) => !binding.isAvailable);
   const [isConfirming, setIsConfirming] = useState(false);
+  const resetButtonRef = useRef<HTMLButtonElement | null>(null);
   const confirmTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
@@ -139,14 +149,52 @@ export function SettingsPage({
     };
   }, []);
 
-  function handleResetClick() {
+  useEffect(() => {
     if (!isConfirming) {
-      setIsConfirming(true);
-      confirmTimerRef.current = setTimeout(() => setIsConfirming(false), 3000);
       return;
     }
 
-    if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    function handlePointerDown(event: PointerEvent) {
+      if (event.target instanceof Node && resetButtonRef.current?.contains(event.target)) {
+        return;
+      }
+
+      if (confirmTimerRef.current) {
+        clearTimeout(confirmTimerRef.current);
+        confirmTimerRef.current = undefined;
+      }
+
+      setIsConfirming(false);
+    }
+
+    window.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [isConfirming]);
+
+  function handleResetClick() {
+    if (!isConfirming) {
+      setIsConfirming(true);
+
+      if (confirmTimerRef.current) {
+        clearTimeout(confirmTimerRef.current);
+      }
+
+      confirmTimerRef.current = setTimeout(() => {
+        confirmTimerRef.current = undefined;
+        setIsConfirming(false);
+      }, 3000);
+
+      return;
+    }
+
+    if (confirmTimerRef.current) {
+      clearTimeout(confirmTimerRef.current);
+      confirmTimerRef.current = undefined;
+    }
+
     setIsConfirming(false);
     onResetToDefaults();
   }
@@ -165,17 +213,17 @@ export function SettingsPage({
           <h1 className={layoutTitleClass}>Set things your way.</h1>
         </div>
         <button
+          ref={resetButtonRef}
           type="button"
-          className={cn(
-            "mb-[2px] rounded-[8px] border px-2.5 py-[4px] text-[11px] font-medium tracking-[-0.01em] transition-all duration-[140ms] ease-out disabled:cursor-not-allowed disabled:opacity-50",
-            isConfirming
-              ? "border-red-500/30 bg-red-500/10 text-red-400 hover:border-red-500/50 hover:bg-red-500/20"
-              : "border-white/8 bg-white/[0.03] text-[rgba(226,232,240,0.48)] hover:border-white/12 hover:bg-white/[0.06] hover:text-[rgba(226,232,240,0.68)]",
-          )}
+          className={resetButtonClass(isConfirming)}
           disabled={isMutating}
           onClick={handleResetClick}
+          aria-label={isConfirming ? "Confirm reset to default settings" : "Reset settings to defaults"}
         >
-          {isConfirming ? "Confirm" : "Reset to defaults"}
+          <span className="invisible" aria-hidden="true">Restore default</span>
+          <span className="pointer-events-none absolute inset-0 flex items-center justify-center font-mono text-[13px]" aria-hidden="true">
+            {isConfirming ? "Confirm" : "Restore default"}
+          </span>
         </button>
       </header>
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, useRef, useEffect, type ReactNode } from "react";
 import type { Display, ShortcutSettings, ShortcutSettingsInput } from "../types";
 import { cn, layoutEyebrowClass, layoutTitleClass, monoTextStyle } from "../ui";
 import { ShortcutField } from "./ShortcutField";
@@ -12,6 +12,7 @@ type SettingsPageProps = {
   onUpdateShortcutSettings: (settings: ShortcutSettingsInput) => Promise<string | null>;
   onToggleAllowCursorExitActiveDisplays: (allowed: boolean) => void;
   onToggleShowOverlayHiddenApps: (enabled: boolean) => void;
+  onResetToDefaults: () => void;
 };
 
 type SettingsSectionProps = {
@@ -126,8 +127,29 @@ export function SettingsPage({
   onUpdateShortcutSettings,
   onToggleAllowCursorExitActiveDisplays,
   onToggleShowOverlayHiddenApps,
+  onResetToDefaults,
 }: SettingsPageProps) {
   const unavailableBindings = shortcutSettings.displayBindings.filter((binding) => !binding.isAvailable);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    };
+  }, []);
+
+  function handleResetClick() {
+    if (!isConfirming) {
+      setIsConfirming(true);
+      confirmTimerRef.current = setTimeout(() => setIsConfirming(false), 3000);
+      return;
+    }
+
+    if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    setIsConfirming(false);
+    onResetToDefaults();
+  }
 
   async function updateShortcutSettings(mutator: (draft: ShortcutSettingsInput) => void) {
     const nextSettings = toShortcutSettingsInput(shortcutSettings);
@@ -137,9 +159,24 @@ export function SettingsPage({
 
   return (
     <section className="flex h-full min-h-0 flex-col gap-3" aria-label="Settings">
-      <header className="shrink-0 px-[2px] pt-[2px]">
-        <span className={layoutEyebrowClass} style={monoTextStyle}>Settings</span>
-        <h1 className={layoutTitleClass}>Set things your way.</h1>
+      <header className="flex shrink-0 items-end justify-between px-[2px] pt-[2px]">
+        <div>
+          <span className={layoutEyebrowClass} style={monoTextStyle}>Settings</span>
+          <h1 className={layoutTitleClass}>Set things your way.</h1>
+        </div>
+        <button
+          type="button"
+          className={cn(
+            "mb-[2px] rounded-[8px] border px-2.5 py-[4px] text-[11px] font-medium tracking-[-0.01em] transition-all duration-[140ms] ease-out disabled:cursor-not-allowed disabled:opacity-50",
+            isConfirming
+              ? "border-red-500/30 bg-red-500/10 text-red-400 hover:border-red-500/50 hover:bg-red-500/20"
+              : "border-white/8 bg-white/[0.03] text-[rgba(226,232,240,0.48)] hover:border-white/12 hover:bg-white/[0.06] hover:text-[rgba(226,232,240,0.68)]",
+          )}
+          disabled={isMutating}
+          onClick={handleResetClick}
+        >
+          {isConfirming ? "Confirm" : "Reset to defaults"}
+        </button>
       </header>
 
       <div className="nocturn-scrollbar min-h-0 flex-1 overflow-y-auto px-[2px] pb-[6px] pr-1.5 pt-[2px] max-[560px]:pr-0.5">

--- a/src/components/ShortcutField.tsx
+++ b/src/components/ShortcutField.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { buildAcceleratorFromKeyboardEvent, formatShortcutForDisplay, isModifierKey } from "../shortcuts";
+import { cn, monoTextStyle } from "../ui";
+
+type ShortcutFieldProps = {
+  title: string;
+  hint: string;
+  value: string | null;
+  disabled: boolean;
+  statusText?: string;
+  onSubmit: (accelerator: string | null) => Promise<string | null>;
+};
+
+const triggerButtonClass = "inline-flex min-w-[156px] items-center justify-center rounded-[12px] border px-3 py-2 text-[13px] font-semibold leading-none tracking-[-0.02em] transition-[border-color,background,box-shadow,transform,opacity] duration-[140ms] ease-out enabled:hover:-translate-y-px disabled:cursor-not-allowed disabled:opacity-50 max-[560px]:w-full";
+const actionButtonClass = "inline-flex items-center justify-center rounded-[12px] border border-white/10 bg-white/[0.03] px-3 py-2 text-[12px] font-medium text-[var(--text-secondary)] transition-[border-color,background,color] duration-[140ms] ease-out enabled:hover:border-white/16 enabled:hover:bg-white/[0.06] enabled:hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-45 max-[560px]:flex-1";
+
+export function ShortcutField({
+  title,
+  hint,
+  value,
+  disabled,
+  statusText,
+  onSubmit,
+}: ShortcutFieldProps) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isCapturing) {
+      triggerRef.current?.focus();
+    }
+  }, [isCapturing]);
+
+  useEffect(() => {
+    setErrorMessage(null);
+  }, [value]);
+
+  async function submitShortcut(accelerator: string | null) {
+    setIsSaving(true);
+    const error = await onSubmit(accelerator);
+    setIsSaving(false);
+
+    if (error) {
+      setErrorMessage(error);
+      return;
+    }
+
+    setErrorMessage(null);
+    setIsCapturing(false);
+  }
+
+  function startCapture() {
+    if (disabled || isSaving) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setIsCapturing(true);
+  }
+
+  async function handleKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>) {
+    if (!isCapturing || disabled || isSaving) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.key === "Escape") {
+      setIsCapturing(false);
+      setErrorMessage(null);
+      return;
+    }
+
+    if (
+      (event.key === "Backspace" || event.key === "Delete")
+      && !event.altKey
+      && !event.ctrlKey
+      && !event.metaKey
+      && !event.shiftKey
+    ) {
+      await submitShortcut(null);
+      return;
+    }
+
+    if (isModifierKey(event.key)) {
+      return;
+    }
+
+    const accelerator = buildAcceleratorFromKeyboardEvent(event.nativeEvent);
+    if (!accelerator) {
+      setErrorMessage("Use at least one modifier key.");
+      return;
+    }
+
+    await submitShortcut(accelerator);
+  }
+
+  async function handleClear() {
+    if (!value || disabled || isSaving) {
+      return;
+    }
+
+    await submitShortcut(null);
+  }
+
+  const triggerLabel = isCapturing
+    ? "Press a shortcut"
+    : value
+      ? formatShortcutForDisplay(value)
+      : "No shortcut set";
+  const isDisabled = disabled || isSaving;
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-[14px] border border-white/8 bg-white/[0.025] px-4 py-3 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:px-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[14px] font-semibold leading-[1.15]">{title}</span>
+          {statusText ? (
+            <span
+              className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] text-[rgba(226,232,240,0.7)]"
+              style={monoTextStyle}
+            >
+              {statusText}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1.5 text-[13px] leading-[1.6] text-[rgba(226,232,240,0.66)]">{hint}</p>
+        {errorMessage ? (
+          <p className="mt-2 text-[12px] leading-[1.5] text-[#fca5a5]">{errorMessage}</p>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2 max-[560px]:w-full max-[560px]:flex-wrap">
+        <button
+          ref={triggerRef}
+          type="button"
+          className={cn(
+            triggerButtonClass,
+            isCapturing
+              ? "border-[rgba(var(--accent-rgb),0.42)] bg-[rgba(var(--accent-rgb),0.18)] text-[var(--accent-soft)] shadow-[0_0_0_1px_rgba(var(--accent-rgb),0.18)]"
+              : value
+                ? "border-[rgba(var(--accent-rgb),0.24)] bg-[rgba(var(--accent-rgb),0.12)] text-[var(--text-primary)]"
+                : "border-white/10 bg-white/[0.03] text-[var(--text-secondary)]",
+          )}
+          onClick={startCapture}
+          onKeyDown={(event) => void handleKeyDown(event)}
+          onBlur={() => {
+            if (!isSaving) {
+              setIsCapturing(false);
+            }
+          }}
+          aria-label={`Set shortcut for ${title}`}
+          aria-pressed={isCapturing}
+          disabled={isDisabled}
+        >
+          <span style={monoTextStyle}>{triggerLabel}</span>
+        </button>
+
+        <button
+          type="button"
+          className={actionButtonClass}
+          onClick={() => void handleClear()}
+          disabled={isDisabled || !value}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ShortcutField.tsx
+++ b/src/components/ShortcutField.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { buildAcceleratorFromKeyboardEvent, formatShortcutForDisplay, isModifierKey } from "../shortcuts";
+import { buildAcceleratorFromKeyboardEvent, isModifierKey } from "../shortcuts";
 import { cn, monoTextStyle } from "../ui";
+import { ShortcutKeycaps } from "./ShortcutKeycaps";
 
 type ShortcutFieldProps = {
   title: string;
@@ -10,9 +11,6 @@ type ShortcutFieldProps = {
   statusText?: string;
   onSubmit: (accelerator: string | null) => Promise<string | null>;
 };
-
-const triggerButtonClass = "inline-flex min-w-[156px] items-center justify-center rounded-[12px] border px-3 py-2 text-[13px] font-semibold leading-none tracking-[-0.02em] transition-[border-color,background,box-shadow,transform,opacity] duration-[140ms] ease-out enabled:hover:-translate-y-px disabled:cursor-not-allowed disabled:opacity-50 max-[560px]:w-full";
-const actionButtonClass = "inline-flex items-center justify-center rounded-[12px] border border-white/10 bg-white/[0.03] px-3 py-2 text-[12px] font-medium text-[var(--text-secondary)] transition-[border-color,background,color] duration-[140ms] ease-out enabled:hover:border-white/16 enabled:hover:bg-white/[0.06] enabled:hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-45 max-[560px]:flex-1";
 
 export function ShortcutField({
   title,
@@ -26,6 +24,7 @@ export function ShortcutField({
   const [isCapturing, setIsCapturing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [feedbackState, setFeedbackState] = useState<"idle" | "saved">("idle");
 
   useEffect(() => {
     if (isCapturing) {
@@ -37,17 +36,32 @@ export function ShortcutField({
     setErrorMessage(null);
   }, [value]);
 
+  useEffect(() => {
+    if (feedbackState !== "saved") {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setFeedbackState("idle");
+    }, 1400);
+
+    return () => window.clearTimeout(timer);
+  }, [feedbackState]);
+
   async function submitShortcut(accelerator: string | null) {
     setIsSaving(true);
+    setFeedbackState("idle");
     const error = await onSubmit(accelerator);
     setIsSaving(false);
 
     if (error) {
       setErrorMessage(error);
+      setFeedbackState("idle");
       return;
     }
 
     setErrorMessage(null);
+    setFeedbackState("saved");
     setIsCapturing(false);
   }
 
@@ -57,6 +71,7 @@ export function ShortcutField({
     }
 
     setErrorMessage(null);
+    setFeedbackState("idle");
     setIsCapturing(true);
   }
 
@@ -98,75 +113,83 @@ export function ShortcutField({
     await submitShortcut(accelerator);
   }
 
-  async function handleClear() {
-    if (!value || disabled || isSaving) {
-      return;
-    }
-
-    await submitShortcut(null);
-  }
-
-  const triggerLabel = isCapturing
-    ? "Press a shortcut"
-    : value
-      ? formatShortcutForDisplay(value)
-      : "No shortcut set";
   const isDisabled = disabled || isSaving;
 
   return (
-    <div className="flex items-center justify-between gap-4 rounded-[14px] border border-white/8 bg-white/[0.025] px-4 py-3 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:px-3">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-[14px] font-semibold leading-[1.15]">{title}</span>
-          {statusText ? (
-            <span
-              className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] text-[rgba(226,232,240,0.7)]"
-              style={monoTextStyle}
-            >
-              {statusText}
-            </span>
-          ) : null}
-        </div>
-        <p className="mt-1.5 text-[13px] leading-[1.6] text-[rgba(226,232,240,0.66)]">{hint}</p>
-        {errorMessage ? (
-          <p className="mt-2 text-[12px] leading-[1.5] text-[#fca5a5]">{errorMessage}</p>
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 rounded-lg py-2.5 transition-[background] duration-[140ms] ease-out max-[560px]:flex-col max-[560px]:items-stretch",
+        isCapturing && "bg-[rgba(var(--accent-rgb),0.06)]",
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="shrink-0 text-[13px] font-semibold leading-[1.15] text-[var(--text-primary)]">
+          {title}
+        </span>
+        <span className="truncate text-[12px] text-[rgba(226,232,240,0.48)]">{hint}</span>
+        {statusText && !isCapturing ? (
+          <span className="shrink-0 text-[11px] text-[rgba(226,232,240,0.38)]" style={monoTextStyle}>
+            {statusText}
+          </span>
         ) : null}
       </div>
 
-      <div className="flex shrink-0 items-center gap-2 max-[560px]:w-full max-[560px]:flex-wrap">
-        <button
-          ref={triggerRef}
-          type="button"
-          className={cn(
-            triggerButtonClass,
-            isCapturing
-              ? "border-[rgba(var(--accent-rgb),0.42)] bg-[rgba(var(--accent-rgb),0.18)] text-[var(--accent-soft)] shadow-[0_0_0_1px_rgba(var(--accent-rgb),0.18)]"
-              : value
-                ? "border-[rgba(var(--accent-rgb),0.24)] bg-[rgba(var(--accent-rgb),0.12)] text-[var(--text-primary)]"
-                : "border-white/10 bg-white/[0.03] text-[var(--text-secondary)]",
-          )}
-          onClick={startCapture}
-          onKeyDown={(event) => void handleKeyDown(event)}
-          onBlur={() => {
-            if (!isSaving) {
-              setIsCapturing(false);
-            }
-          }}
-          aria-label={`Set shortcut for ${title}`}
-          aria-pressed={isCapturing}
-          disabled={isDisabled}
-        >
-          <span style={monoTextStyle}>{triggerLabel}</span>
-        </button>
+      <div className="flex shrink-0 items-center gap-2">
+        {isCapturing ? (
+          <>
+            <span className="animate-pulse text-[12px] text-[var(--accent-soft)]" style={monoTextStyle}>
+              Press shortcut...
+            </span>
+            <span className="text-[10px] text-[rgba(226,232,240,0.36)]" style={monoTextStyle}>
+              Esc cancel
+            </span>
+            {/* Hidden button to capture key events */}
+            <button
+              ref={triggerRef}
+              type="button"
+              className="sr-only"
+              onKeyDown={(event) => void handleKeyDown(event)}
+              onBlur={() => {
+                if (!isSaving) {
+                  setIsCapturing(false);
+                }
+              }}
+              aria-label={`Recording shortcut for ${title}`}
+            />
+          </>
+        ) : (
+          <>
+            {errorMessage ? (
+              <span className="text-[11px] text-[#fca5a5]">{errorMessage}</span>
+            ) : null}
 
-        <button
-          type="button"
-          className={actionButtonClass}
-          onClick={() => void handleClear()}
-          disabled={isDisabled || !value}
-        >
-          Clear
-        </button>
+            {feedbackState === "saved" ? (
+              <span className="text-[10px] uppercase tracking-[0.08em] text-[#6ee7b7]" style={monoTextStyle}>
+                Saved
+              </span>
+            ) : null}
+
+            <button
+              ref={triggerRef}
+              type="button"
+              className={cn(
+                "group flex items-center gap-2 rounded-md px-1.5 py-1 transition-colors duration-[140ms] ease-out",
+                "hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+              onClick={startCapture}
+              aria-label={`Set shortcut for ${title}`}
+              disabled={isDisabled}
+            >
+              {value ? (
+                <ShortcutKeycaps accelerator={value} size="sm" />
+              ) : (
+                <span className="text-[12px] text-[var(--text-secondary)]" style={monoTextStyle}>
+                  Set shortcut
+                </span>
+              )}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/ShortcutField.tsx
+++ b/src/components/ShortcutField.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { buildAcceleratorFromKeyboardEvent, isModifierKey } from "../shortcuts";
+import { useEffect, useRef, useState } from "react";
+import { buildAcceleratorFromHeldCodes, isModifierCode } from "../shortcuts";
 import { cn, monoTextStyle } from "../ui";
 import { ShortcutKeycaps } from "./ShortcutKeycaps";
 
@@ -21,10 +21,16 @@ export function ShortcutField({
   onSubmit,
 }: ShortcutFieldProps) {
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const heldCodes = useRef(new Set<string>());
   const [isCapturing, setIsCapturing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [feedbackState, setFeedbackState] = useState<"idle" | "saved">("idle");
+  const isSavingRef = useRef(false);
+
+  useEffect(() => {
+    isSavingRef.current = isSaving;
+  }, [isSaving]);
 
   useEffect(() => {
     if (isCapturing) {
@@ -47,6 +53,60 @@ export function ShortcutField({
 
     return () => window.clearTimeout(timer);
   }, [feedbackState]);
+
+  // Track held keys at the window level so modifier state is always accurate,
+  // even when Chromium/WebView2 misreports event.ctrlKey on certain layouts.
+  useEffect(() => {
+    if (!isCapturing) {
+      heldCodes.current.clear();
+      return;
+    }
+
+    // Delay modifier keyup removal by a short window. Windows sends a
+    // synthetic Shift keyup right before numpad keydown when NumLock is on,
+    // which would otherwise cause heldCodes to lose Shift before we read it.
+    const pendingRemovals = new Map<string, number>();
+
+    function onKeyDown(event: KeyboardEvent) {
+      const pending = pendingRemovals.get(event.code);
+      if (pending !== undefined) {
+        window.clearTimeout(pending);
+        pendingRemovals.delete(event.code);
+      }
+      heldCodes.current.add(event.code);
+    }
+
+    function onKeyUp(event: KeyboardEvent) {
+      if (isModifierCode(event.code)) {
+        const timer = window.setTimeout(() => {
+          heldCodes.current.delete(event.code);
+          pendingRemovals.delete(event.code);
+        }, 50);
+        pendingRemovals.set(event.code, timer);
+      } else {
+        heldCodes.current.delete(event.code);
+      }
+    }
+
+    function onWindowBlur() {
+      for (const timer of pendingRemovals.values()) window.clearTimeout(timer);
+      pendingRemovals.clear();
+      heldCodes.current.clear();
+    }
+
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("blur", onWindowBlur);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("blur", onWindowBlur);
+      for (const timer of pendingRemovals.values()) window.clearTimeout(timer);
+      pendingRemovals.clear();
+      heldCodes.current.clear();
+    };
+  }, [isCapturing]);
 
   async function submitShortcut(accelerator: string | null) {
     setIsSaving(true);
@@ -75,8 +135,8 @@ export function ShortcutField({
     setIsCapturing(true);
   }
 
-  async function handleKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>) {
-    if (!isCapturing || disabled || isSaving) {
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (!isCapturing || disabled || isSavingRef.current) {
       return;
     }
 
@@ -89,28 +149,32 @@ export function ShortcutField({
       return;
     }
 
+    // Allow bare Backspace/Delete to clear the shortcut (check held codes
+    // for modifiers instead of event flags, consistent with the rest).
     if (
       (event.key === "Backspace" || event.key === "Delete")
-      && !event.altKey
-      && !event.ctrlKey
-      && !event.metaKey
-      && !event.shiftKey
+      && !heldCodes.current.has("AltLeft") && !heldCodes.current.has("AltRight")
+      && !heldCodes.current.has("ControlLeft") && !heldCodes.current.has("ControlRight")
+      && !heldCodes.current.has("MetaLeft") && !heldCodes.current.has("MetaRight")
+      && !heldCodes.current.has("ShiftLeft") && !heldCodes.current.has("ShiftRight")
     ) {
-      await submitShortcut(null);
+      void submitShortcut(null);
       return;
     }
 
-    if (isModifierKey(event.key)) {
+    if (isModifierCode(event.nativeEvent.code)) {
       return;
     }
 
-    const accelerator = buildAcceleratorFromKeyboardEvent(event.nativeEvent);
+    // Build accelerator by merging manually tracked modifier state with
+    // event flags — covers both AZERTY and NumLock+Shift edge cases.
+    const accelerator = buildAcceleratorFromHeldCodes(heldCodes.current, event.nativeEvent);
     if (!accelerator) {
       setErrorMessage("Use at least one modifier key.");
       return;
     }
 
-    await submitShortcut(accelerator);
+    void submitShortcut(accelerator);
   }
 
   const isDisabled = disabled || isSaving;
@@ -148,9 +212,9 @@ export function ShortcutField({
               ref={triggerRef}
               type="button"
               className="sr-only"
-              onKeyDown={(event) => void handleKeyDown(event)}
+              onKeyDown={handleKeyDown}
               onBlur={() => {
-                if (!isSaving) {
+                if (!isSavingRef.current) {
                   setIsCapturing(false);
                 }
               }}

--- a/src/components/ShortcutKeycaps.tsx
+++ b/src/components/ShortcutKeycaps.tsx
@@ -1,0 +1,62 @@
+import { formatShortcutTokensForDisplay } from "../shortcuts";
+import { cn, monoTextStyle } from "../ui";
+
+type ShortcutKeycapsProps = {
+  accelerator: string | null | undefined;
+  size?: "sm" | "xs";
+  className?: string;
+};
+
+const groupGapClass = {
+  sm: "gap-[3px]",
+  xs: "gap-[2px]",
+} as const;
+
+const tokenGapClass = {
+  sm: "gap-[3px]",
+  xs: "gap-[2px]",
+} as const;
+
+const separatorClass = {
+  sm: "text-[9px]",
+  xs: "text-[7px]",
+} as const;
+
+const keycapClass = {
+  sm: "min-w-[18px] h-[18px] px-[5px] text-[9px]",
+  xs: "min-w-[14px] h-[15px] px-[4px] text-[7px]",
+} as const;
+
+export function ShortcutKeycaps({ accelerator, size = "sm", className }: ShortcutKeycapsProps) {
+  const tokens = formatShortcutTokensForDisplay(accelerator);
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("flex max-w-full flex-wrap items-center normal-case", groupGapClass[size], className)}
+    >
+      {tokens.map((token, index) => (
+        <span key={`${token}-${index}`} className={cn("inline-flex items-center", tokenGapClass[size])}>
+          {index > 0 ? (
+            <span className={cn("text-[rgba(226,232,240,0.52)]", separatorClass[size])} style={monoTextStyle}>
+              +
+            </span>
+          ) : null}
+          <span
+            className={cn(
+              "inline-flex items-center justify-center whitespace-nowrap rounded-[4px] border border-white/10 text-[rgba(248,250,252,0.9)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_-1px_0_rgba(8,10,14,0.36),0_1px_1px_rgba(8,10,14,0.18)] [background:linear-gradient(180deg,rgba(255,255,255,0.14),rgba(255,255,255,0.04)_62%),rgba(148,163,184,0.05)]",
+              keycapClass[size],
+            )}
+            style={monoTextStyle}
+          >
+            {token}
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/src/hooks/useDisplays.ts
+++ b/src/hooks/useDisplays.ts
@@ -225,6 +225,24 @@ export function useDisplays() {
     }
   }, [loadDisplays]);
 
+  const resetToDefaults = useCallback(async () => {
+    setIsMutating(true);
+
+    try {
+      const payload = await withTimeout(
+        invoke<DisplayUpdatePayload>("reset_to_defaults"),
+        "Resetting to defaults",
+      );
+
+      setState((current) => applyPayload(current, payload));
+    } catch (error) {
+      console.error("Failed to reset to defaults:", error);
+      void loadDisplays();
+    } finally {
+      setIsMutating(false);
+    }
+  }, [loadDisplays]);
+
   const setShortcutSettings = useCallback(async (hotkeys: ShortcutSettingsInput) => {
     setIsMutating(true);
 
@@ -262,6 +280,7 @@ export function useDisplays() {
     toggleDisplay,
     restoreAllDisplays,
     focusPrimary,
+    resetToDefaults,
     setAllowCursorExitActiveDisplays,
     setShowOverlayHiddenApps,
     setShortcutSettings,

--- a/src/hooks/useDisplays.ts
+++ b/src/hooks/useDisplays.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { Display, DisplayUpdatePayload } from "../types";
+import type { Display, DisplayUpdatePayload, ShortcutSettings, ShortcutSettingsInput } from "../types";
 
 type UseDisplaysState = {
   displays: Display[];
@@ -10,6 +10,12 @@ type UseDisplaysState = {
   blackoutCount: number;
   allowCursorExitActiveDisplays: boolean;
   showOverlayHiddenApps: boolean;
+  shortcutSettings: ShortcutSettings;
+};
+
+const EMPTY_SHORTCUT_SETTINGS: ShortcutSettings = {
+  focusModeHotkey: null,
+  displayBindings: [],
 };
 
 const INITIAL_STATE: UseDisplaysState = {
@@ -19,6 +25,7 @@ const INITIAL_STATE: UseDisplaysState = {
   blackoutCount: 0,
   allowCursorExitActiveDisplays: true,
   showOverlayHiddenApps: true,
+  shortcutSettings: EMPTY_SHORTCUT_SETTINGS,
 };
 
 const COMMAND_TIMEOUT_MS = 5000;
@@ -42,6 +49,31 @@ function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = COMMAND_
   });
 }
 
+function applyPayload(current: UseDisplaysState, payload: DisplayUpdatePayload): UseDisplaysState {
+  return {
+    ...current,
+    displays: payload.displays,
+    activeDisplayCount: payload.activeDisplayCount,
+    blackoutCount: payload.blackoutCount,
+    allowCursorExitActiveDisplays: payload.allowCursorExitActiveDisplays,
+    showOverlayHiddenApps: payload.showOverlayHiddenApps,
+    shortcutSettings: payload.shortcutSettings,
+    isLoading: false,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unknown error.";
+}
+
 export function useDisplays() {
   const [state, setState] = useState<UseDisplaysState>(INITIAL_STATE);
   const [isMutating, setIsMutating] = useState(false);
@@ -50,15 +82,7 @@ export function useDisplays() {
   const loadDisplays = useCallback(async () => {
     try {
       const payload = await withTimeout(invoke<DisplayUpdatePayload>("get_displays"), "Loading displays");
-      setState((current) => ({
-        ...current,
-        displays: payload.displays,
-        activeDisplayCount: payload.activeDisplayCount,
-        blackoutCount: payload.blackoutCount,
-        allowCursorExitActiveDisplays: payload.allowCursorExitActiveDisplays,
-        showOverlayHiddenApps: payload.showOverlayHiddenApps,
-        isLoading: false,
-      }));
+      setState((current) => applyPayload(current, payload));
     } catch (error) {
       console.error("Failed to load displays:", error);
       setState((current) => ({
@@ -74,15 +98,7 @@ export function useDisplays() {
     void loadDisplays();
 
     void listen<DisplayUpdatePayload>("displays-update", (event) => {
-      setState((current) => ({
-        ...current,
-        displays: event.payload.displays,
-        activeDisplayCount: event.payload.activeDisplayCount,
-        blackoutCount: event.payload.blackoutCount,
-        allowCursorExitActiveDisplays: event.payload.allowCursorExitActiveDisplays,
-        showOverlayHiddenApps: event.payload.showOverlayHiddenApps,
-        isLoading: false,
-      }));
+      setState((current) => applyPayload(current, event.payload));
     }).then((cleanup) => {
       unlisten = cleanup;
     });
@@ -182,13 +198,7 @@ export function useDisplays() {
         "Updating cursor setting",
       );
 
-      setState((current) => ({
-        ...current,
-        displays: payload.displays,
-        activeDisplayCount: payload.activeDisplayCount,
-        blackoutCount: payload.blackoutCount,
-        allowCursorExitActiveDisplays: payload.allowCursorExitActiveDisplays,
-      }));
+      setState((current) => applyPayload(current, payload));
     } catch (error) {
       console.error("Failed to update cursor setting:", error);
       void loadDisplays();
@@ -206,17 +216,30 @@ export function useDisplays() {
         "Updating overlay app labels",
       );
 
-      setState((current) => ({
-        ...current,
-        displays: payload.displays,
-        activeDisplayCount: payload.activeDisplayCount,
-        blackoutCount: payload.blackoutCount,
-        allowCursorExitActiveDisplays: payload.allowCursorExitActiveDisplays,
-        showOverlayHiddenApps: payload.showOverlayHiddenApps,
-      }));
+      setState((current) => applyPayload(current, payload));
     } catch (error) {
       console.error("Failed to update overlay app labels:", error);
       void loadDisplays();
+    } finally {
+      setIsMutating(false);
+    }
+  }, [loadDisplays]);
+
+  const setShortcutSettings = useCallback(async (hotkeys: ShortcutSettingsInput) => {
+    setIsMutating(true);
+
+    try {
+      const payload = await withTimeout(
+        invoke<DisplayUpdatePayload>("set_shortcut_settings", { hotkeys }),
+        "Updating shortcut settings",
+      );
+
+      setState((current) => applyPayload(current, payload));
+      return null;
+    } catch (error) {
+      console.error("Failed to update shortcut settings:", error);
+      void loadDisplays();
+      return getErrorMessage(error);
     } finally {
       setIsMutating(false);
     }
@@ -241,6 +264,7 @@ export function useDisplays() {
     focusPrimary,
     setAllowCursorExitActiveDisplays,
     setShowOverlayHiddenApps,
+    setShortcutSettings,
     lastActiveDisplayId,
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
   --bg: #0d0d12;
   --surface: rgba(255, 255, 255, 0.04);
   --surface-hover: rgba(255, 255, 255, 0.065);
+  --surface-strong: rgba(255, 255, 255, 0.075);
   --border: rgba(255, 255, 255, 0.07);
   --border-on: rgba(52, 211, 153, 0.28);
   --border-off: rgba(239, 68, 68, 0.26);
@@ -18,6 +19,8 @@
   --accent-strong: #9d90ff;
   --accent-soft: #d9d2ff;
   --accent-glow: rgba(var(--accent-rgb), 0.35);
+  --scroll-track: rgba(255, 255, 255, 0.04);
+  --scroll-thumb: rgba(var(--accent-rgb), 0.38);
 }
 
 html,
@@ -40,6 +43,40 @@ button {
 
 button:enabled {
   cursor: pointer;
+}
+
+.nocturn-scrollbar {
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scroll-thumb) var(--scroll-track);
+}
+
+.nocturn-scrollbar::-webkit-scrollbar {
+  width: 10px;
+}
+
+.nocturn-scrollbar::-webkit-scrollbar-track {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: var(--scroll-track);
+  background-clip: padding-box;
+}
+
+.nocturn-scrollbar::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(var(--accent-rgb), 0.55), rgba(var(--accent-rgb), 0.26));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 0 0 1px rgba(var(--accent-rgb), 0.08);
+  background-clip: padding-box;
+}
+
+.nocturn-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, rgba(var(--accent-rgb), 0.72), rgba(var(--accent-rgb), 0.34));
+  background-clip: padding-box;
+}
+
+.nocturn-scrollbar::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 @keyframes blink {

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -1,0 +1,179 @@
+const CODE_LABELS: Record<string, string> = {
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  ArrowUp: "Up",
+  Backquote: "`",
+  Backslash: "\\",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Comma: ",",
+  Delete: "Delete",
+  End: "End",
+  Enter: "Enter",
+  Equal: "=",
+  Escape: "Esc",
+  Home: "Home",
+  Insert: "Insert",
+  Minus: "-",
+  NumpadAdd: "NumAdd",
+  NumpadDecimal: "NumDecimal",
+  NumpadDivide: "NumDivide",
+  NumpadEnter: "NumEnter",
+  NumpadEqual: "NumEqual",
+  NumpadMultiply: "NumMultiply",
+  NumpadSubtract: "NumSubtract",
+  PageDown: "PageDown",
+  PageUp: "PageUp",
+  Pause: "Pause",
+  Period: ".",
+  PrintScreen: "PrintScreen",
+  Quote: "'",
+  ScrollLock: "ScrollLock",
+  Semicolon: ";",
+  Slash: "/",
+  Space: "Space",
+  Tab: "Tab",
+};
+
+const TOKEN_LABELS: Record<string, string> = {
+  alt: "Alt",
+  arrowdown: "Down",
+  arrowleft: "Left",
+  arrowright: "Right",
+  arrowup: "Up",
+  backquote: "`",
+  backslash: "\\",
+  bracketleft: "[",
+  bracketright: "]",
+  cmd: "Super",
+  cmdorcontrol: "Ctrl",
+  cmdorctrl: "Ctrl",
+  comma: ",",
+  command: "Super",
+  commandorcontrol: "Ctrl",
+  commandorctrl: "Ctrl",
+  control: "Ctrl",
+  ctrl: "Ctrl",
+  delete: "Delete",
+  down: "Down",
+  end: "End",
+  enter: "Enter",
+  equal: "=",
+  escape: "Esc",
+  esc: "Esc",
+  home: "Home",
+  insert: "Insert",
+  left: "Left",
+  meta: "Super",
+  minus: "-",
+  numadd: "NumAdd",
+  numdecimal: "NumDecimal",
+  numdivide: "NumDivide",
+  numenter: "NumEnter",
+  numequal: "NumEqual",
+  nummultiply: "NumMultiply",
+  numsubtract: "NumSubtract",
+  option: "Alt",
+  pagedown: "PageDown",
+  pageup: "PageUp",
+  pause: "Pause",
+  period: ".",
+  printscreen: "PrintScreen",
+  quote: "'",
+  right: "Right",
+  scrolllock: "ScrollLock",
+  semicolon: ";",
+  shift: "Shift",
+  slash: "/",
+  space: "Space",
+  super: "Super",
+  tab: "Tab",
+  up: "Up",
+};
+
+export function isModifierKey(key: string) {
+  return key === "Alt" || key === "Control" || key === "Meta" || key === "Shift";
+}
+
+export function buildAcceleratorFromKeyboardEvent(event: KeyboardEvent): string | null {
+  const key = keyLabelFromCode(event.code);
+  if (!key) {
+    return null;
+  }
+
+  const modifiers = [
+    event.ctrlKey ? "Ctrl" : null,
+    event.altKey ? "Alt" : null,
+    event.shiftKey ? "Shift" : null,
+    event.metaKey ? "Super" : null,
+  ].filter((value): value is string => value !== null);
+
+  if (modifiers.length === 0) {
+    return null;
+  }
+
+  return [...modifiers, key].join("+");
+}
+
+export function formatShortcutForDisplay(accelerator: string | null | undefined) {
+  if (!accelerator) {
+    return "";
+  }
+
+  return accelerator
+    .split("+")
+    .map((token) => formatToken(token))
+    .filter(Boolean)
+    .join("+");
+}
+
+function keyLabelFromCode(code: string): string | null {
+  if (/^Key[A-Z]$/i.test(code)) {
+    return code.slice(3).toUpperCase();
+  }
+
+  if (/^Digit\d$/i.test(code)) {
+    return code.slice(5);
+  }
+
+  if (/^Numpad\d$/i.test(code)) {
+    return `Num${code.slice(6)}`;
+  }
+
+  if (/^F\d{1,2}$/i.test(code)) {
+    return code.toUpperCase();
+  }
+
+  return CODE_LABELS[code] ?? null;
+}
+
+function formatToken(rawToken: string) {
+  const token = rawToken.trim();
+  if (!token) {
+    return "";
+  }
+
+  const normalized = token.toLowerCase();
+  if (TOKEN_LABELS[normalized]) {
+    return TOKEN_LABELS[normalized];
+  }
+
+  if (/^key[a-z]$/i.test(token)) {
+    return token.slice(3).toUpperCase();
+  }
+
+  if (/^digit\d$/i.test(token)) {
+    return token.slice(5);
+  }
+
+  if (/^numpad\d$/i.test(token)) {
+    return `Num${token.slice(6)}`;
+  }
+
+  if (/^f\d{1,2}$/i.test(token)) {
+    return token.toUpperCase();
+  }
+
+  return token.length === 1 ? token.toUpperCase() : token;
+}

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -117,15 +117,18 @@ export function buildAcceleratorFromKeyboardEvent(event: KeyboardEvent): string 
 }
 
 export function formatShortcutForDisplay(accelerator: string | null | undefined) {
+  return formatShortcutTokensForDisplay(accelerator).join("+");
+}
+
+export function formatShortcutTokensForDisplay(accelerator: string | null | undefined) {
   if (!accelerator) {
-    return "";
+    return [];
   }
 
   return accelerator
     .split("+")
     .map((token) => formatToken(token))
-    .filter(Boolean)
-    .join("+");
+    .filter((token): token is string => Boolean(token));
 }
 
 function keyLabelFromCode(code: string): string | null {

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -92,21 +92,45 @@ const TOKEN_LABELS: Record<string, string> = {
   up: "Up",
 };
 
+const MODIFIER_CODES: ReadonlySet<string> = new Set([
+  "ControlLeft", "ControlRight",
+  "AltLeft", "AltRight",
+  "ShiftLeft", "ShiftRight",
+  "MetaLeft", "MetaRight",
+]);
+
+export function isModifierCode(code: string) {
+  return MODIFIER_CODES.has(code);
+}
+
 export function isModifierKey(key: string) {
   return key === "Alt" || key === "Control" || key === "Meta" || key === "Shift";
 }
 
-export function buildAcceleratorFromKeyboardEvent(event: KeyboardEvent): string | null {
+/**
+ * Build an accelerator string by merging two sources of modifier state:
+ *
+ * 1. `heldCodes` — physical key codes tracked via keydown/keyup on window.
+ *    Fixes Chromium/WebView2 misreporting event.ctrlKey on non-US layouts
+ *    (e.g. AZERTY Ctrl+Shift+digit loses Ctrl).
+ *
+ * 2. `event` — the native KeyboardEvent modifier flags.
+ *    Fixes Windows sending a synthetic Shift keyup before numpad keys when
+ *    NumLock is on, which causes heldCodes to lose Shift prematurely.
+ *
+ * A modifier is included if EITHER source reports it as held.
+ */
+export function buildAcceleratorFromHeldCodes(heldCodes: ReadonlySet<string>, event: KeyboardEvent): string | null {
   const key = keyLabelFromCode(event.code);
   if (!key) {
     return null;
   }
 
   const modifiers = [
-    event.ctrlKey ? "Ctrl" : null,
-    event.altKey ? "Alt" : null,
-    event.shiftKey ? "Shift" : null,
-    event.metaKey ? "Super" : null,
+    (event.ctrlKey || heldCodes.has("ControlLeft") || heldCodes.has("ControlRight")) ? "Ctrl" : null,
+    (event.altKey || heldCodes.has("AltLeft") || heldCodes.has("AltRight")) ? "Alt" : null,
+    (event.shiftKey || heldCodes.has("ShiftLeft") || heldCodes.has("ShiftRight")) ? "Shift" : null,
+    (event.metaKey || heldCodes.has("MetaLeft") || heldCodes.has("MetaRight")) ? "Super" : null,
   ].filter((value): value is string => value !== null);
 
   if (modifiers.length === 0) {
@@ -120,15 +144,24 @@ export function formatShortcutForDisplay(accelerator: string | null | undefined)
   return formatShortcutTokensForDisplay(accelerator).join("+");
 }
 
+const MODIFIER_ORDER: Record<string, number> = { Ctrl: 0, Alt: 1, Shift: 2, Super: 3 };
+
 export function formatShortcutTokensForDisplay(accelerator: string | null | undefined) {
   if (!accelerator) {
     return [];
   }
 
-  return accelerator
+  const tokens = accelerator
     .split("+")
     .map((token) => formatToken(token))
     .filter((token): token is string => Boolean(token));
+
+  // Sort modifiers into canonical order (Ctrl, Alt, Shift, Super) while keeping
+  // the main key last. The backend may re-serialize in a different order.
+  const modifiers = tokens.filter((token) => token in MODIFIER_ORDER);
+  const keys = tokens.filter((token) => !(token in MODIFIER_ORDER));
+  modifiers.sort((a, b) => MODIFIER_ORDER[a] - MODIFIER_ORDER[b]);
+  return [...modifiers, ...keys];
 }
 
 function keyLabelFromCode(code: string): string | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,32 @@ export type OverlayCardPresentation = {
   isEnabled: boolean;
 };
 
+export type DisplayShortcutBinding = {
+  displayKey: string;
+  displayLabel: string;
+  accelerator: string;
+};
+
+export type DisplayShortcutBindingInfo = DisplayShortcutBinding & {
+  isAvailable: boolean;
+};
+
+export type ShortcutSettings = {
+  focusModeHotkey: string | null;
+  displayBindings: DisplayShortcutBindingInfo[];
+};
+
+export type ShortcutSettingsInput = {
+  focusModeHotkey: string | null;
+  displayBindings: DisplayShortcutBinding[];
+};
+
 export type Display = {
   id: string;
   name: string;
   manufacturer: string;
   model: string;
+  persistentKey: string;
   width: number;
   height: number;
   x: number;
@@ -27,6 +48,7 @@ export type Display = {
   isBlackedOut: boolean;
   hostsPanel: boolean;
   canBlackout: boolean;
+  hotkey: string | null;
   hiddenApps: HiddenAppSummary[];
 };
 
@@ -36,4 +58,5 @@ export type DisplayUpdatePayload = {
   blackoutCount: number;
   allowCursorExitActiveDisplays: boolean;
   showOverlayHiddenApps: boolean;
+  shortcutSettings: ShortcutSettings;
 };


### PR DESCRIPTION
## Summary
- add persistent global shortcuts for each display and for focus mode, with more reliable capture across keyboard layouts and numpads
- rework the settings and display UI around shortcut editing with inline keycaps, reset-to-defaults support, and header polish
- prepare the v0.1.4 release metadata and disable title-bar double-click maximization while keeping window dragging intact

## Testing
- npm run build
- cargo check

Fixes #6